### PR TITLE
Revise event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ let window = Window::new(make_widget! {
     }
     impl {
         fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: Message)
-            -> EmptyMsg
+            -> VoidResponse
         {
             match msg {
                 Message::Decr => {
@@ -116,7 +116,7 @@ let window = Window::new(make_widget! {
                     self.display.set_text(tk, self.counter.to_string());
                 }
             };
-            EmptyMsg
+            VoidResponse::None
         }
     }
 });

--- a/kas-macros/src/args.rs
+++ b/kas-macros/src/args.rs
@@ -359,7 +359,7 @@ pub struct HandlerArgs {
 
 impl Parse for HandlerArgs {
     fn parse(input: ParseStream) -> Result<Self> {
-        let mut msg = parse_quote! { kas::event::EmptyMsg };
+        let mut msg = parse_quote! { kas::event::VoidMsg };
         let mut generics = Generics::default();
 
         if input.is_empty() {

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -147,13 +147,13 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             // TODO(opt): it is possible to code more efficient search strategies
             ev_to_num.append_all(quote! {
                 if id <= self.#ident.id() {
-                    let r = self.#ident.handle(_tk, Event::ToChild(id, e));
+                    let r = self.#ident.handle(_tk, addr, event);
                     #handler
                 } else
             });
             ev_to_coord.append_all(quote! {
                 if self.#ident.rect().contains(coord) {
-                    let r = self.#ident.handle(_tk, Event::ToCoord(coord, e));
+                    let r = self.#ident.handle(_tk, addr, event);
                     #handler
                 } else
             });
@@ -164,20 +164,20 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             quote! {}
         } else {
             quote! {
-                fn handle(&mut self, _tk: &mut dyn kas::TkWindow, event: kas::event::Event)
+                fn handle(&mut self, _tk: &mut dyn kas::TkWindow, addr: kas::event::Address, event: kas::event::Event)
                 -> kas::event::Response<Self::Msg>
                 {
                     use kas::{WidgetCore, event::{Event, Response}};
-                    match event {
-                        Event::ToChild(id, e) => {
+                    match addr {
+                        kas::event::Address::Id(id) => {
                             #ev_to_num {
                                 debug_assert!(id == self.id(), "Handler::handle: bad WidgetId");
-                                Response::Unhandled(e)
+                                Response::Unhandled(event)
                             }
                         }
-                        Event::ToCoord(coord, e) => {
+                        kas::event::Address::Coord(coord) => {
                             #ev_to_coord {
-                                kas::event::Manager::handle_generic(self, _tk, Event::ToCoord(coord, e))
+                                kas::event::Manager::handle_generic(self, _tk, event)
                             }
                         }
                     }

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -10,15 +10,14 @@ use std::num::ParseFloatError;
 use std::str::FromStr;
 
 use kas::class::HasText;
-use kas::event::EmptyMsg;
 use kas::event::VirtualKeyCode as VK;
-use kas::macros::{make_widget, EmptyMsg};
+use kas::event::{Response, VoidMsg};
+use kas::macros::{make_widget, VoidMsg};
 use kas::widget::{EditBox, TextButton, Window};
 use kas::TkWindow;
 
-#[derive(Clone, Debug, EmptyMsg)]
+#[derive(Clone, Debug, VoidMsg)]
 enum Key {
-    None,
     Clear,
     Divide,
     Multiply,
@@ -70,18 +69,18 @@ fn main() -> Result<(), winit::error::OsError> {
         }
     };
     let content = make_widget! {
-        vertical => EmptyMsg;
+        vertical => VoidMsg;
         struct {
             #[widget] display: impl HasText = EditBox::new("0").editable(false).multi_line(true),
             #[widget(handler = handle_button)] buttons -> Key = buttons,
             calc: Calculator = Calculator::new(),
         }
         impl {
-            fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: Key) -> EmptyMsg {
+            fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: Key) -> Response<VoidMsg> {
                 if self.calc.handle(msg) {
                     self.display.set_text(tk, self.calc.display());
                 }
-                EmptyMsg
+                Response::None
             }
         }
     };
@@ -149,7 +148,6 @@ impl Calculator {
     // return true if display changes
     fn handle(&mut self, key: Key) -> bool {
         match key {
-            Key::None => false,
             Key::Clear => {
                 self.state = Ok(0.0);
                 self.op = Op::None;

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -12,15 +12,14 @@ use chrono::prelude::*;
 use std::time::Duration;
 
 use kas::class::HasText;
-use kas::event::Callback;
-use kas::event::EmptyMsg;
+use kas::event::{Callback, VoidMsg};
 use kas::macros::make_widget;
 use kas::widget::{Label, Window};
 use kas::{TkWindow, WidgetCore};
 
 fn main() {
     let mut window = Window::new(make_widget! {
-        vertical => EmptyMsg;
+        vertical => VoidMsg;
         struct {
             #[widget] date: Label = Label::new(""),
             #[widget] time: Label = Label::new("")

--- a/kas-wgpu/examples/counter.rs
+++ b/kas-wgpu/examples/counter.rs
@@ -7,14 +7,13 @@
 #![feature(proc_macro_hygiene)]
 
 use kas::class::HasText;
-use kas::event::EmptyMsg;
-use kas::macros::{make_widget, EmptyMsg};
+use kas::event::{VoidMsg, VoidResponse};
+use kas::macros::{make_widget, VoidMsg};
 use kas::widget::{Label, TextButton, Window};
 use kas::TkWindow;
 
-#[derive(Clone, Debug, EmptyMsg)]
+#[derive(Clone, Debug, VoidMsg)]
 enum Message {
-    None,
     Decr,
     Incr,
 }
@@ -28,7 +27,7 @@ fn main() -> Result<(), winit::error::OsError> {
         }
     };
     let window = Window::new(make_widget! {
-        vertical => EmptyMsg;
+        vertical => VoidMsg;
         struct {
             #[widget] display: Label = Label::from("0"),
             #[widget(handler = handle_button)] buttons -> Message = buttons,
@@ -36,10 +35,9 @@ fn main() -> Result<(), winit::error::OsError> {
         }
         impl {
             fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: Message)
-                -> EmptyMsg
+                -> VoidResponse
             {
                 match msg {
-                    Message::None => (),
                     Message::Decr => {
                         self.counter = self.counter.saturating_sub(1);
                         self.display.set_text(tk, self.counter.to_string());
@@ -49,7 +47,7 @@ fn main() -> Result<(), winit::error::OsError> {
                         self.display.set_text(tk, self.counter.to_string());
                     }
                 };
-                EmptyMsg
+                VoidResponse::None
             }
         }
     });

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -6,14 +6,13 @@
 //! Gallery of all widgets
 #![feature(proc_macro_hygiene)]
 
-use kas::event::EmptyMsg;
-use kas::macros::{make_widget, EmptyMsg};
+use kas::event::{VoidMsg, VoidResponse};
+use kas::macros::{make_widget, VoidMsg};
 use kas::widget::*;
 use kas::TkWindow;
 
-#[derive(Clone, Debug, EmptyMsg)]
+#[derive(Clone, Debug, VoidMsg)]
 enum Item {
-    None,
     Button,
     Check(bool),
     Edit(String),
@@ -45,10 +44,10 @@ fn main() -> Result<(), winit::error::OsError> {
     };
 
     let window = Window::new(make_widget! {
-        vertical => EmptyMsg;
+        vertical => VoidMsg;
         struct {
             #[widget] _ = make_widget! {
-                frame => EmptyMsg;
+                frame => VoidMsg;
                 struct {
                     #[widget] _ = Label::from("Widget Gallery"),
                 }
@@ -57,15 +56,14 @@ fn main() -> Result<(), winit::error::OsError> {
         }
         impl {
             fn activations(&mut self, _: &mut dyn TkWindow, item: Item)
-                -> EmptyMsg
+                -> VoidResponse
             {
                 match item {
-                    Item::None => (),
                     Item::Button => println!("Clicked!"),
                     Item::Check(b) => println!("Checkbox: {}", b),
                     Item::Edit(s) => println!("Edited: {}", s),
                 };
-                EmptyMsg
+                VoidResponse::None
             }
         }
     });

--- a/kas-wgpu/examples/layout.rs
+++ b/kas-wgpu/examples/layout.rs
@@ -6,7 +6,7 @@
 //! Gallery of all widgets
 #![feature(proc_macro_hygiene)]
 
-use kas::event::EmptyMsg;
+use kas::event::VoidMsg;
 use kas::macros::make_widget;
 use kas::widget::{CheckBox, EditBox, Label, Window};
 
@@ -15,7 +15,7 @@ fn main() -> Result<(), winit::error::OsError> {
     let crasit = "Cras sit amet justo ipsum. Aliquam in nunc posuere leo egestas laoreet convallis eu libero. Nullam ut massa ante. Cras vitae velit pharetra, euismod nisl suscipit, feugiat nulla. Aenean consectetur, diam non tristique iaculis, nisl lectus hendrerit sapien, nec rhoncus mi sem non odio. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla a lorem eu ipsum faucibus placerat ac quis quam. Curabitur justo ligula, laoreet nec ultrices eu, scelerisque non metus. Mauris sit amet est enim. Mauris risus eros, accumsan ut iaculis sit amet, sagittis facilisis neque. Nunc venenatis risus nec purus malesuada, a tristique arcu efficitur. Nulla suscipit arcu nibh. Cras facilisis nibh a gravida aliquet. Praesent fringilla felis a tristique luctus.";
 
     let window = Window::new(make_widget! {
-        grid => EmptyMsg;
+        grid => VoidMsg;
         struct {
             #[widget(row=0, col=2)] _ = Label::from("Layout demo"),
             #[widget(row=1, col=1, cspan=3)] _ = Label::from(lipsum),

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -10,14 +10,13 @@ use std::fmt::Write;
 use std::time::{Duration, Instant};
 
 use kas::class::HasText;
-use kas::event::{Callback, EmptyMsg};
-use kas::macros::{make_widget, EmptyMsg};
+use kas::event::{Callback, Response, VoidMsg};
+use kas::macros::{make_widget, VoidMsg};
 use kas::widget::{Label, TextButton, Window};
 use kas::TkWindow;
 
-#[derive(Clone, Debug, EmptyMsg)]
+#[derive(Clone, Debug, VoidMsg)]
 enum Control {
-    None,
     Reset,
     Start,
 }
@@ -26,10 +25,10 @@ enum Control {
 // There's no reason for this, but it demonstrates usage of Toolkit::add_boxed
 fn make_window() -> Box<dyn kas::Window> {
     let stopwatch = make_widget! {
-        horizontal => EmptyMsg;
+        horizontal => VoidMsg;
         struct {
             #[widget] display: impl HasText = make_widget!{
-                frame => EmptyMsg;
+                frame => VoidMsg;
                 struct {
                     #[widget] display: Label = Label::from("0.000"),
                 }
@@ -49,9 +48,8 @@ fn make_window() -> Box<dyn kas::Window> {
             dur_buf: String = String::default(),
         }
         impl {
-            fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: Control) -> EmptyMsg {
+            fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: Control) -> Response<VoidMsg> {
                 match msg {
-                    Control::None => {}
                     Control::Reset => {
                         self.saved = Duration::default();
                         self.start = None;
@@ -66,7 +64,7 @@ fn make_window() -> Box<dyn kas::Window> {
                         }
                     }
                 }
-                EmptyMsg
+                Response::None
             }
 
             fn on_tick(&mut self, tk: &mut dyn TkWindow) {

--- a/kas-wgpu/examples/theme.rs
+++ b/kas-wgpu/examples/theme.rs
@@ -9,8 +9,8 @@
 use std::cell::Cell;
 
 use kas::draw::Colour;
-use kas::event::EmptyMsg;
-use kas::macros::{make_widget, EmptyMsg};
+use kas::event::{VoidMsg, VoidResponse};
+use kas::macros::{make_widget, VoidMsg};
 use kas::theme::Theme;
 use kas::widget::*;
 use kas::TkWindow;
@@ -78,9 +78,8 @@ impl Theme<DrawPipe> for ColouredTheme {
     }
 }
 
-#[derive(Clone, Debug, EmptyMsg)]
+#[derive(Clone, Debug, VoidMsg)]
 enum Item {
-    None,
     White,
     Red,
     Green,
@@ -102,22 +101,21 @@ fn main() -> Result<(), winit::error::OsError> {
     let theme = ColouredTheme::new();
 
     let window = Window::new(make_widget! {
-        single => EmptyMsg;
+        single => VoidMsg;
         struct {
             #[widget(handler = handler)] _ = widgets,
         }
         impl {
             fn handler(&mut self, _: &mut dyn TkWindow, item: Item)
-                -> EmptyMsg
+                -> VoidResponse
             {
                 match item {
-                    Item::None => (),
                     Item::White => BACKGROUND.with(|b| b.set(Colour::grey(1.0))),
                     Item::Red => BACKGROUND.with(|b| b.set(Colour::new(0.9, 0.2, 0.2))),
                     Item::Green => BACKGROUND.with(|b| b.set(Colour::new(0.2, 0.9, 0.2))),
                     Item::Yellow => BACKGROUND.with(|b| b.set(Colour::new(0.9, 0.9, 0.2))),
                 };
-                EmptyMsg
+                VoidResponse::None
             }
         }
     });

--- a/kas-wgpu/src/theme.rs
+++ b/kas-wgpu/src/theme.rs
@@ -73,7 +73,7 @@ fn nav_colour(highlights: HighlightState) -> Option<Colour> {
 
 fn button_colour(highlights: HighlightState, show: bool) -> Option<Colour> {
     if highlights.depress {
-        Some(Colour::new(0.2, 0.6, 0.8))
+        Some(Colour::new(0.15, 0.525, 0.75))
     } else if show && highlights.hover {
         Some(Colour::new(0.25, 0.8, 1.0))
     } else if show {

--- a/kas-wgpu/src/theme.rs
+++ b/kas-wgpu/src/theme.rs
@@ -368,7 +368,7 @@ impl<'a> theme::DrawHandle for DrawHandle<'a> {
     }
 
     fn checkbox(&mut self, pos: Coord, checked: bool, highlights: HighlightState) {
-        let pos = Vec2::from(pos);
+        let pos = Vec2::from(pos + self.offset);
         let size = 2.0 * (self.window.frame_size + self.window.margin) + self.window.font_scale;
         let size = Vec2::splat(size);
         let mut quad = Quad(pos, pos + size);

--- a/src/event/enums.rs
+++ b/src/event/enums.rs
@@ -7,6 +7,8 @@
 //!
 //! These are simply copied from winit.
 
+#![allow(unused)]
+
 /// Describes the input state of a key.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -52,6 +52,7 @@ pub enum Event {
     PressEnd {
         source: PressSource,
         start_id: Option<WidgetId>,
+        end_id: Option<WidgetId>,
         coord: Coord,
     },
 }

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -10,6 +10,13 @@ use super::MouseButton;
 use crate::geom::Coord;
 use crate::WidgetId;
 
+/// Delivery address of an [`Event`]
+#[derive(Clone, Copy, Debug)]
+pub enum Address {
+    Id(WidgetId),
+    Coord(Coord),
+}
+
 /// High-level events addressed to a widget by [`WidgetId`]
 #[derive(Clone, Debug)]
 pub enum Action {
@@ -21,26 +28,9 @@ pub enum Action {
     Scroll(ScrollDelta),
 }
 
-/// Input events: these are low-level messages where the destination widget is
-/// unknown.
-///
-/// These events are segregated by delivery method.
+/// Low-level events addressed to a widget by [`WidgetId`] or coordinate.
 #[derive(Clone, Debug)]
 pub enum Event {
-    /* NOTE: it's tempting to add this, but we have no model for returning a
-     * response from multiple recipients and no use-case.
-    /// Events to be addressed to all descendents
-    ToAll(EventAll),
-    */
-    /// Events addressed to a child by [`WidgetId`]
-    ToChild(WidgetId, EventChild),
-    /// Events addressed by coordinate
-    ToCoord(Coord, EventChild),
-}
-
-/// Low-level events addressed to a widget by [`WidgetId`]
-#[derive(Clone, Debug)]
-pub enum EventChild {
     Action(Action),
     Identify,
     /// A mouse button was pressed or touch event started

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -17,7 +17,7 @@ use crate::geom::Coord;
 use crate::WidgetId;
 
 /// High-level actions supported by widgets
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Action {
     /// Widget activation, for example clicking a button or toggling a check-box
     Activate,
@@ -29,7 +29,7 @@ pub enum Action {
 /// unknown.
 ///
 /// These events are segregated by delivery method.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Event {
     /* NOTE: it's tempting to add this, but we have no model for returning a
      * response from multiple recipients and no use-case.
@@ -43,7 +43,7 @@ pub enum Event {
 }
 
 /// Events addressed to a child by [`WidgetId`]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum EventChild {
     Action(Action),
     MouseInput {
@@ -55,7 +55,7 @@ pub enum EventChild {
 }
 
 /// Events addressed by coordinate
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum EventCoord {
     CursorMoved { modifiers: ModifiersState },
     TouchStart(u64),
@@ -64,7 +64,7 @@ pub enum EventCoord {
 }
 
 /// Type used by [`EventChild::Scroll`]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum ScrollDelta {
     /// Scroll a given number of lines
     LineDelta(f32, f32),

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -1,0 +1,99 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Event handling - handler
+
+use crate::event::{Action, Event, EventChild, Manager, Response};
+use crate::{TkWindow, Widget};
+
+/// Event-handling aspect of a widget.
+///
+/// This is a companion trait to [`Widget`]. It can (optionally) be implemented
+/// by the `derive(Widget)` macro, or can be implemented manually.
+///
+/// [`Widget`]: crate::Widget
+pub trait Handler: Widget {
+    /// Type of message returned by this handler.
+    ///
+    /// This mechanism allows type-safe handling of user-defined responses to handled actions.
+    /// For example, a user may define a control panel where each button returns a unique code,
+    /// or a configuration editor may return a full copy of the new configuration on completion.
+    type Msg;
+
+    /// Handle a high-level "action" and return a user-defined message.
+    ///
+    /// Widgets should handle any events applicable to themselves here, and
+    /// return all other events via [`Response::Unhandled`].
+    #[inline]
+    fn handle_action(&mut self, _: &mut dyn TkWindow, action: Action) -> Response<Self::Msg> {
+        Response::Unhandled(EventChild::Action(action))
+    }
+
+    /// Handle a low-level event.
+    ///
+    /// Most non-parent widgets will not need to implement this method manually.
+    /// The default implementation (which wraps [`Manager::handle_generic`])
+    /// forwards high-level events via [`Handler::handle_action`].
+    ///
+    /// Parent widgets should forward events to the appropriate child widget,
+    /// translating event coordinates where applicable. Unused events should be
+    /// handled (directly or through [`Manager::handle_generic`]) or returned
+    /// via [`Response::Unhandled`]. The return-value from child handlers may
+    /// be intercepted in order to handle as-yet-unhandled events.
+    ///
+    /// Additionally, this method allows lower-level interpretation of some
+    /// events, e.g. more direct access to mouse inputs.
+    #[inline]
+    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
+        Manager::handle_generic(self, tk, event)
+    }
+}
+
+impl Manager {
+    /// Generic handler for low-level events passed to leaf widgets
+    pub fn handle_generic<W>(
+        widget: &mut W,
+        tk: &mut dyn TkWindow,
+        event: Event,
+    ) -> Response<<W as Handler>::Msg>
+    where
+        W: Handler + ?Sized,
+    {
+        match event {
+            Event::ToChild(_, ev) | Event::ToCoord(_, ev) => match ev {
+                EventChild::Action(action) => widget.handle_action(tk, action),
+                EventChild::Identify => Response::Identify(widget.id()),
+                ev @ _ => Response::Unhandled(ev),
+            },
+        }
+    }
+
+    /// Handler for low-level events passed to leaf widgets, supporting
+    /// activation via mouse and touch.
+    // TODO: this will likely be replaced with some more generic handler
+    pub fn handle_activable<W>(
+        widget: &mut W,
+        tk: &mut dyn TkWindow,
+        event: Event,
+    ) -> Response<<W as Handler>::Msg>
+    where
+        W: Handler + ?Sized,
+    {
+        match event {
+            Event::ToChild(_, ev) | Event::ToCoord(_, ev) => match ev {
+                EventChild::Action(action) => widget.handle_action(tk, action),
+                EventChild::Identify => Response::Identify(widget.id()),
+                EventChild::PressStart { source, coord } if source.is_primary() => {
+                    tk.update_data(&mut |data| data.request_press_grab(source, widget.id(), coord));
+                    Response::None
+                }
+                EventChild::PressEnd { start_id, .. } if start_id == Some(widget.id()) => {
+                    widget.handle_action(tk, Action::Activate)
+                }
+                ev @ _ => Response::Unhandled(ev),
+            },
+        }
+    }
+}

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -78,6 +78,10 @@ impl Manager {
                 tk.update_data(&mut |data| data.request_press_grab(source, widget.id(), coord));
                 Response::None
             }
+            Event::PressMove { .. } if activable => {
+                // We don't need these events, but they should not be considered *unhandled*
+                Response::None
+            }
             Event::PressEnd { start_id, .. } if activable && start_id == Some(widget.id()) => {
                 widget.handle_action(tk, Action::Activate)
             }

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -82,7 +82,9 @@ impl Manager {
                 // We don't need these events, but they should not be considered *unhandled*
                 Response::None
             }
-            Event::PressEnd { start_id, .. } if activable && start_id == Some(widget.id()) => {
+            Event::PressEnd {
+                start_id, end_id, ..
+            } if activable && start_id == Some(widget.id()) && start_id == end_id => {
                 widget.handle_action(tk, Action::Activate)
             }
             ev @ _ => Response::Unhandled(ev),

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -75,7 +75,9 @@ impl Manager {
             Event::Action(action) => widget.handle_action(tk, action),
             Event::Identify => Response::Identify(widget.id()),
             Event::PressStart { source, coord } if activable && source.is_primary() => {
-                tk.update_data(&mut |data| data.request_press_grab(source, widget.id(), coord));
+                tk.update_data(&mut |data| {
+                    data.request_press_grab(source, widget.as_widget(), coord)
+                });
                 Response::None
             }
             Event::PressMove { .. } if activable => {

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -475,14 +475,14 @@ impl Manager {
                         // TODO: using grab_id as start_id is incorrect when
                         // multiple buttons are pressed simultaneously
                         ElementState::Pressed => Event::PressStart { source, coord },
-                        ElementState::Released => Event::PressEnd { source, start_id: Some(grab_id), coord },
+                        ElementState::Released => Event::PressEnd { source, start_id: Some(grab_id), end_id: tk.data().hover, coord },
                     };
                     widget.handle(tk, Address::Id(grab_id), ev)
                 } else if let Some(id) = tk.data().hover {
                     // No mouse grab, but we have a hover target
                     let ev = match state {
                         ElementState::Pressed => Event::PressStart { source, coord },
-                        ElementState::Released => Event::PressEnd { source, start_id: None, coord },
+                        ElementState::Released => Event::PressEnd { source, start_id: None, end_id: Some(id), coord },
                     };
                     widget.handle(tk, Address::Id(id), ev)
                 } else {
@@ -528,10 +528,11 @@ impl Manager {
                             data.char_focus = None;
                             r
                         });
-                        if let Some(PressEvent { start_id, .. }) = tk.data().touch_grab(touch.id) {
+                        if let Some(PressEvent { start_id, cur_id, .. }) = tk.data().touch_grab(touch.id) {
                             let action = Event::PressEnd {
                                 source,
                                 start_id: Some(start_id),
+                                end_id: Some(cur_id),
                                 coord,
                             };
                             let r = widget.handle(tk, Address::Id(start_id), action);
@@ -541,6 +542,7 @@ impl Manager {
                             let action = Event::PressEnd {
                                 source,
                                 start_id: None,
+                                end_id: None,
                                 coord,
                             };
                             widget.handle(tk, Address::Coord(coord), action)

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -188,7 +188,10 @@ impl Manager {
     /// Request a mouse grab on the given input source
     ///
     /// If successful, corresponding move/end events will be forwarded to the
-    /// given `w_id`. The grab automatically ends after the end event.
+    /// given `w_id`. The grab automatically ends after the end event. Since
+    /// these events are *requested*, the widget should consume them even if
+    /// e.g. the move events are not needed (although in practice this only
+    /// affects parents intercepting [`Response::Unhandled`] events).
     ///
     /// In the case that multiple widgets attempt to grab the same source, only
     /// the first will be successful.

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -47,31 +47,13 @@ pub struct VoidMsg;
 /// Alias for `Response<VoidMsg>`
 pub type VoidResponse = Response<VoidMsg>;
 
-/// Mark explicitly ignored events.
+/// Consume an unhandled [`Action`] and return `Response::None`.
 ///
 /// This is an error, meaning somehow an event has been sent to a widget which
 /// does not support events of that type.
 /// It is safe to ignore this error, but this function panics in debug builds.
-pub fn err_unhandled<M: Debug, N>(m: M) -> Response<N> {
-    debug_assert!(
-        false,
-        "Handler::handle: event not handled by widget: {:?}",
-        m
-    );
-    println!("Handler::handle: event not handled by widget: {:?}", m);
-    Response::None
-}
-
-/// Notify of an incorrect widget identifier.
-///
-/// This is an error, meaning somehow an event has been sent to a
-/// [`WidgetId`] which is not a child of the initial window/widget.
-/// It is safe to ignore this error, but this function panics in debug builds.
-///
-/// [`WidgetId`]: crate::WidgetId
-pub fn err_num<N>() -> Response<N> {
-    debug_assert!(false, "Handler::handle: bad WidgetId");
-    println!("Handler::handle: bad widget WidgetId");
+pub fn unhandled_action<A: Debug, N>(a: A) -> Response<N> {
+    debug_assert!(false, "unhandled_action: {:?}", a);
     Response::None
 }
 

--- a/src/event/response.rs
+++ b/src/event/response.rs
@@ -6,6 +6,7 @@
 //! Event handling: Response type
 
 use super::EventChild;
+use crate::WidgetId;
 
 /// Response type from [`Handler::handle`].
 ///
@@ -19,6 +20,8 @@ use super::EventChild;
 pub enum Response<M> {
     /// No action
     None,
+    /// Identification of a widget
+    Identify(WidgetId),
     /// Unhandled input events get returned back up the widget tree
     Unhandled(EventChild),
     /// Custom message type
@@ -28,6 +31,15 @@ pub enum Response<M> {
 // Unfortunately we cannot write generic `From` / `TryFrom` impls
 // due to trait coherence rules, so we impl `from` etc. directly.
 impl<M> Response<M> {
+    /// True if variant is `None`
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        match self {
+            &Response::None => true,
+            _ => false,
+        }
+    }
+
     /// Map from one `Response` type to another
     ///
     /// Once Rust supports specialisation, this will likely be replaced with a
@@ -59,6 +71,7 @@ impl<M> Response<M> {
         use Response::*;
         match r {
             None => Ok(None),
+            Identify(id) => Ok(Identify(id)),
             Unhandled(e) => Ok(Unhandled(e)),
             Msg(m) => Err(m),
         }

--- a/src/event/response.rs
+++ b/src/event/response.rs
@@ -1,0 +1,73 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Event handling: Response type
+
+/// Response type from [`Handler::handle`].
+///
+/// This type wraps [`Handler::Msg`] allowing both custom messages and toolkit
+/// messages.
+///
+/// [`Handler::handle`]: super::Handler::handle
+/// [`Handler::Msg`]: super::Handler::Msg
+#[derive(Copy, Clone, Debug)]
+#[must_use]
+pub enum Response<M> {
+    /// No action
+    None,
+    /// Custom message type
+    Msg(M),
+}
+
+// Unfortunately we cannot write generic `From` / `TryFrom` impls
+// due to trait coherence rules, so we impl `from` etc. directly.
+impl<M> Response<M> {
+    /// Map from one `Response` type to another
+    ///
+    /// Once Rust supports specialisation, this will likely be replaced with a
+    /// `From` implementation.
+    #[inline]
+    pub fn from<N>(r: Response<N>) -> Self
+    where
+        M: From<N>,
+    {
+        r.try_into().unwrap_or_else(|msg| Response::Msg(M::from(msg)))
+    }
+
+    /// Map one `Response` type into another
+    ///
+    /// Once Rust supports specialisation, this will likely be redundant.
+    #[inline]
+    pub fn into<N>(self) -> Response<N>
+    where
+        N: From<M>,
+    {
+        Response::from(self)
+    }
+
+    /// Try mapping from one `Response` type to another, failing on `Msg`
+    /// variant and returning the payload.
+    #[inline]
+    pub fn try_from<N>(r: Response<N>) -> Result<Self, N> {
+        use Response::*;
+        match r {
+            None => Ok(None),
+            Msg(m) => Err(m),
+        }
+    }
+
+    /// Try mapping one `Response` type into another, failing on `Msg`
+    /// variant and returning the payload.
+    #[inline]
+    pub fn try_into<N>(self) -> Result<Response<N>, M> {
+        Response::try_from(self)
+    }
+}
+
+impl<M> From<M> for Response<M> {
+    fn from(msg: M) -> Self {
+        Response::Msg(msg)
+    }
+}

--- a/src/event/response.rs
+++ b/src/event/response.rs
@@ -5,6 +5,8 @@
 
 //! Event handling: Response type
 
+use super::EventChild;
+
 /// Response type from [`Handler::handle`].
 ///
 /// This type wraps [`Handler::Msg`] allowing both custom messages and toolkit
@@ -12,11 +14,13 @@
 ///
 /// [`Handler::handle`]: super::Handler::handle
 /// [`Handler::Msg`]: super::Handler::Msg
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[must_use]
 pub enum Response<M> {
     /// No action
     None,
+    /// Unhandled input events get returned back up the widget tree
+    Unhandled(EventChild),
     /// Custom message type
     Msg(M),
 }
@@ -33,7 +37,8 @@ impl<M> Response<M> {
     where
         M: From<N>,
     {
-        r.try_into().unwrap_or_else(|msg| Response::Msg(M::from(msg)))
+        r.try_into()
+            .unwrap_or_else(|msg| Response::Msg(M::from(msg)))
     }
 
     /// Map one `Response` type into another
@@ -54,6 +59,7 @@ impl<M> Response<M> {
         use Response::*;
         match r {
             None => Ok(None),
+            Unhandled(e) => Ok(Unhandled(e)),
             Msg(m) => Err(m),
         }
     }

--- a/src/event/response.rs
+++ b/src/event/response.rs
@@ -5,7 +5,7 @@
 
 //! Event handling: Response type
 
-use super::Event;
+use super::{Action, Event};
 use crate::WidgetId;
 
 /// Response type from [`Handler::handle`].
@@ -38,6 +38,14 @@ impl<M> Response<M> {
             &Response::None => true,
             _ => false,
         }
+    }
+
+    /// Produce [`Response::Unhandled`] variant from an [`Action`]
+    ///
+    /// Convenience function for common usage.
+    #[inline]
+    pub fn unhandled_action(action: Action) -> Self {
+        Response::Unhandled(Event::Action(action))
     }
 
     /// Map from one `Response` type to another

--- a/src/event/response.rs
+++ b/src/event/response.rs
@@ -5,7 +5,7 @@
 
 //! Event handling: Response type
 
-use super::EventChild;
+use super::Event;
 use crate::WidgetId;
 
 /// Response type from [`Handler::handle`].
@@ -23,7 +23,7 @@ pub enum Response<M> {
     /// Identification of a widget
     Identify(WidgetId),
     /// Unhandled input events get returned back up the widget tree
-    Unhandled(EventChild),
+    Unhandled(Event),
     /// Custom message type
     Msg(M),
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,8 +14,8 @@
 //!     traits like [`WidgetCore`] and optionally [`Handler`])
 //! -   [`make_widget`] is a convenience macro to create a single instance of a
 //!     custom widget type
-//! -   [`derive(EmptyMsg)`] is a convenience macro to implement
-//!     `From<EmptyMsg>` for the deriving enum
+//! -   [`derive(VoidMsg)`] is a convenience macro to implement
+//!     `From<VoidMsg>` for the deriving type
 //!
 //! Note that these macros are defined in the external crate, `kas-macros`, only
 //! because procedural macros must be defined in a special crate. The
@@ -29,7 +29,7 @@
 //!
 //! [`make_widget`]: #the-make_widget-macro
 //! [`derive(Widget)`]: #the-derivewidget-macro
-//! [`derive(EmptyMsg)`]: #the-deriveemptymsg-macro
+//! [`derive(VoidMsg)`]: #the-derivevoidmsg-macro
 //!
 //!
 //! ## The `derive(Widget)` macro
@@ -131,19 +131,15 @@
 //! A longer example, including derivation of the [`Handler`] trait:
 //!
 //! ```
-//! use kas::event::{Handler, err_unhandled};
-//! use kas::macros::{Widget, EmptyMsg};
+//! use kas::event::{Handler, VoidResponse, VoidMsg, err_unhandled};
+//! use kas::macros::Widget;
 //! use kas::{CoreData, LayoutData, TkWindow, Widget};
 //!
-//! #[derive(Debug, EmptyMsg)]
-//! enum ChildMessage { None, A }
-//!
-//! #[derive(EmptyMsg)]
-//! enum MyMessage { None }
+//! #[derive(Debug)]
+//! enum ChildMessage { A }
 //!
 //! #[widget(layout = single)]
-//! #[handler(msg = MyMessage,
-//!         generics = <> where W: Handler<Msg = ChildMessage>)]
+//! #[handler(generics = <> where W: Handler<Msg = ChildMessage>)]
 //! #[derive(Debug, Widget)]
 //! struct MyWidget<W: Widget> {
 //!     #[core] core: CoreData,
@@ -152,14 +148,11 @@
 //! }
 //!
 //! impl<W: Widget> MyWidget<W> {
-//!     fn handler(&mut self, tk: &dyn TkWindow, msg: ChildMessage) -> MyMessage {
+//!     fn handler(&mut self, tk: &dyn TkWindow, msg: ChildMessage) -> VoidResponse {
 //!         match msg {
-//!             ChildMessage::None => (),
-//!             ChildMessage::A => {
-//!                 println!("handling ChildMessage::A");
-//!             }
+//!             ChildMessage::A => { println!("handling ChildMessage::A"); }
 //!         }
-//!         MyMessage::None
+//!         VoidResponse::None
 //!     }
 //! }
 //! ```
@@ -225,12 +218,11 @@
 //! ```
 //! #![feature(proc_macro_hygiene)]
 //!
-//! use kas::macros::{EmptyMsg, make_widget};
+//! use kas::macros::{make_widget};
 //! use kas::widget::TextButton;
 //!
-//! #[derive(Copy, Clone, Debug, EmptyMsg)]
+//! #[derive(Copy, Clone, Debug)]
 //! enum OkCancel {
-//!     None,
 //!     Ok,
 //!     Cancel,
 //! }
@@ -245,20 +237,19 @@
 //! ```
 //!
 //!
-//! ## The `derive(EmptyMsg)` macro
+//! ## The `derive(VoidMsg)` macro
 //!
-//! This macro implements `From<EmptyMsg>` for the given type (see [`EmptyMsg`]).
-//! It assumes that the type is an enum with a simple variant named `None`.
+//! This macro implements `From<VoidMsg>` for the given type (see [`VoidMsg`]).
 //!
-//! [`EmptyMsg`]: crate::event::EmptyMsg
+//! [`VoidMsg`]: crate::event::VoidMsg
 //!
 //! ### Example
 //!
 //! ```
-//! use kas::macros::EmptyMsg;
+//! use kas::macros::VoidMsg;
 //!
-//! #[derive(EmptyMsg)]
-//! enum MyMessage { None, A, B };
+//! #[derive(VoidMsg)]
+//! enum MyMessage { A, B };
 //! ```
 //!
 //! [`Core`]: crate::Core
@@ -268,4 +259,4 @@
 //! [`CoreData`]: crate::CoreData
 //! [`Handler::Msg`]: ../kas/event/trait.Handler.html#associatedtype.Msg
 
-pub use kas_macros::{make_widget, EmptyMsg, Widget};
+pub use kas_macros::{make_widget, VoidMsg, Widget};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -131,7 +131,7 @@
 //! A longer example, including derivation of the [`Handler`] trait:
 //!
 //! ```
-//! use kas::event::{Handler, VoidResponse, VoidMsg, err_unhandled};
+//! use kas::event::{Handler, VoidResponse, VoidMsg};
 //! use kas::macros::Widget;
 //! use kas::{CoreData, LayoutData, TkWindow, Widget};
 //!

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,7 +7,7 @@
 
 use std::fmt;
 
-use crate::event::{self, Callback, EmptyMsg, Handler};
+use crate::event::{self, Callback, Handler, VoidMsg};
 use crate::geom::{Rect, Size};
 use crate::layout::{self, AxisInfo, SizeRules};
 use crate::theme::{DrawHandle, SizeHandle};
@@ -189,7 +189,7 @@ pub trait LayoutData {
 // Window should be a Widget. So alternatives are (1) use a struct instead of a
 // trait or (2) allow any Widget to derive Window (i.e. implement required
 // functionality with macros instead of the generic code below).
-pub trait Window: Widget + Handler<Msg = EmptyMsg> {
+pub trait Window: Widget + Handler<Msg = VoidMsg> {
     /// Adjust the size of the window, repositioning widgets.
     fn resize(&mut self, tk: &mut dyn TkWindow, size: Size);
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -8,7 +8,7 @@
 use std::fmt::Debug;
 
 use crate::class::HasText;
-use crate::event::{self, Action, Event, EventChild, Handler, Manager, Response, VirtualKeyCode};
+use crate::event::{self, Action, Address, Event, Handler, Manager, Response, VirtualKeyCode};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -108,12 +108,12 @@ impl<M: Clone + Debug> Handler for TextButton<M> {
     fn handle_action(&mut self, _: &mut dyn TkWindow, action: Action) -> Response<M> {
         match action {
             Action::Activate => self.msg.clone().into(),
-            a @ _ => Response::Unhandled(EventChild::Action(a)),
+            a @ _ => Response::Unhandled(Event::Action(a)),
         }
     }
 
     #[inline]
-    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
+    fn handle(&mut self, tk: &mut dyn TkWindow, _: Address, event: Event) -> Response<Self::Msg> {
         Manager::handle_activable(self, tk, event)
     }
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -8,7 +8,7 @@
 use std::fmt::Debug;
 
 use crate::class::HasText;
-use crate::event::{self, err_unhandled, Action, EmptyMsg, Handler, VirtualKeyCode};
+use crate::event::{self, err_unhandled, Action, Handler, Response, VirtualKeyCode};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -18,7 +18,7 @@ use kas::geom::Rect;
 /// A push-button with a text label
 #[widget]
 #[derive(Clone, Debug, Default, Widget)]
-pub struct TextButton<M: Clone + Debug + From<EmptyMsg>> {
+pub struct TextButton<M: Clone + Debug> {
     #[core]
     core: CoreData,
     text_rect: Rect,
@@ -26,7 +26,7 @@ pub struct TextButton<M: Clone + Debug + From<EmptyMsg>> {
     msg: M,
 }
 
-impl<M: Clone + Debug + From<EmptyMsg>> Widget for TextButton<M> {
+impl<M: Clone + Debug> Widget for TextButton<M> {
     fn allow_focus(&self) -> bool {
         true
     }
@@ -58,7 +58,7 @@ impl<M: Clone + Debug + From<EmptyMsg>> Widget for TextButton<M> {
     }
 }
 
-impl<M: Clone + Debug + From<EmptyMsg>> TextButton<M> {
+impl<M: Clone + Debug> TextButton<M> {
     /// Construct a button with a given `label` and `msg`
     ///
     /// The message `msg` is returned to the parent widget on activation. Any
@@ -91,7 +91,7 @@ impl<M: Clone + Debug + From<EmptyMsg>> TextButton<M> {
     }
 }
 
-impl<M: Clone + Debug + From<EmptyMsg>> HasText for TextButton<M> {
+impl<M: Clone + Debug> HasText for TextButton<M> {
     fn get_text(&self) -> &str {
         &self.label
     }
@@ -102,10 +102,10 @@ impl<M: Clone + Debug + From<EmptyMsg>> HasText for TextButton<M> {
     }
 }
 
-impl<M: Clone + Debug + From<EmptyMsg>> Handler for TextButton<M> {
+impl<M: Clone + Debug> Handler for TextButton<M> {
     type Msg = M;
 
-    fn handle_action(&mut self, _: &mut dyn TkWindow, action: Action) -> M {
+    fn handle_action(&mut self, _: &mut dyn TkWindow, action: Action) -> Response<M> {
         match action {
             Action::Activate => self.msg.clone().into(),
             a @ _ => err_unhandled(a),

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -8,7 +8,7 @@
 use std::fmt::Debug;
 
 use crate::class::HasText;
-use crate::event::{self, err_unhandled, Action, Handler, Response, VirtualKeyCode};
+use crate::event::{self, unhandled_action, Action, Handler, Response, VirtualKeyCode};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -108,7 +108,7 @@ impl<M: Clone + Debug> Handler for TextButton<M> {
     fn handle_action(&mut self, _: &mut dyn TkWindow, action: Action) -> Response<M> {
         match action {
             Action::Activate => self.msg.clone().into(),
-            a @ _ => err_unhandled(a),
+            a @ _ => unhandled_action(a),
         }
     }
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -8,7 +8,7 @@
 use std::fmt::Debug;
 
 use crate::class::HasText;
-use crate::event::{self, Action, Address, Event, Handler, Manager, Response, VirtualKeyCode};
+use crate::event::{self, Action, Handler, Response, VirtualKeyCode};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -105,15 +105,15 @@ impl<M: Clone + Debug> HasText for TextButton<M> {
 impl<M: Clone + Debug> Handler for TextButton<M> {
     type Msg = M;
 
+    #[inline]
+    fn activation_via_press(&self) -> bool {
+        true
+    }
+
     fn handle_action(&mut self, _: &mut dyn TkWindow, action: Action) -> Response<M> {
         match action {
             Action::Activate => self.msg.clone().into(),
             a @ _ => Response::unhandled_action(a),
         }
-    }
-
-    #[inline]
-    fn handle(&mut self, tk: &mut dyn TkWindow, _: Address, event: Event) -> Response<Self::Msg> {
-        Manager::handle_activable(self, tk, event)
     }
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -8,7 +8,7 @@
 use std::fmt::Debug;
 
 use crate::class::HasText;
-use crate::event::{self, unhandled_action, Action, Handler, Response, VirtualKeyCode};
+use crate::event::{self, Action, Event, EventChild, Handler, Manager, Response, VirtualKeyCode};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -108,7 +108,12 @@ impl<M: Clone + Debug> Handler for TextButton<M> {
     fn handle_action(&mut self, _: &mut dyn TkWindow, action: Action) -> Response<M> {
         match action {
             Action::Activate => self.msg.clone().into(),
-            a @ _ => unhandled_action(a),
+            a @ _ => Response::Unhandled(EventChild::Action(a)),
         }
+    }
+
+    #[inline]
+    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
+        Manager::handle_activable(self, tk, event)
     }
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -108,7 +108,7 @@ impl<M: Clone + Debug> Handler for TextButton<M> {
     fn handle_action(&mut self, _: &mut dyn TkWindow, action: Action) -> Response<M> {
         match action {
             Action::Activate => self.msg.clone().into(),
-            a @ _ => Response::Unhandled(Event::Action(a)),
+            a @ _ => Response::unhandled_action(a),
         }
     }
 

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -182,7 +182,7 @@ impl Handler for CheckBox<()> {
                 tk.redraw(self.id());
                 Response::None
             }
-            a @ _ => Response::Unhandled(Event::Action(a)),
+            a @ _ => Response::unhandled_action(a),
         }
     }
 
@@ -202,7 +202,7 @@ impl<M, H: Fn(bool) -> M> Handler for CheckBox<H> {
                 tk.redraw(self.id());
                 ((self.on_toggle)(self.state)).into()
             }
-            a @ _ => Response::Unhandled(Event::Action(a)),
+            a @ _ => Response::unhandled_action(a),
         }
     }
 

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -8,7 +8,7 @@
 use std::fmt::{self, Debug};
 
 use crate::class::{HasBool, HasText};
-use crate::event::{self, Action, Event, EventChild, Handler, Manager, Response, VoidMsg};
+use crate::event::{self, Action, Address, Event, Handler, Manager, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -182,12 +182,12 @@ impl Handler for CheckBox<()> {
                 tk.redraw(self.id());
                 Response::None
             }
-            a @ _ => Response::Unhandled(EventChild::Action(a)),
+            a @ _ => Response::Unhandled(Event::Action(a)),
         }
     }
 
     #[inline]
-    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
+    fn handle(&mut self, tk: &mut dyn TkWindow, _: Address, event: Event) -> Response<Self::Msg> {
         Manager::handle_activable(self, tk, event)
     }
 }
@@ -202,12 +202,12 @@ impl<M, H: Fn(bool) -> M> Handler for CheckBox<H> {
                 tk.redraw(self.id());
                 ((self.on_toggle)(self.state)).into()
             }
-            a @ _ => Response::Unhandled(EventChild::Action(a)),
+            a @ _ => Response::Unhandled(Event::Action(a)),
         }
     }
 
     #[inline]
-    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
+    fn handle(&mut self, tk: &mut dyn TkWindow, _: Address, event: Event) -> Response<Self::Msg> {
         Manager::handle_activable(self, tk, event)
     }
 }

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -8,7 +8,7 @@
 use std::fmt::{self, Debug};
 
 use crate::class::{HasBool, HasText};
-use crate::event::{self, Action, Address, Event, Handler, Manager, Response, VoidMsg};
+use crate::event::{self, Action, Handler, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -175,6 +175,11 @@ impl<H> HasText for CheckBox<H> {
 impl Handler for CheckBox<()> {
     type Msg = VoidMsg;
 
+    #[inline]
+    fn activation_via_press(&self) -> bool {
+        true
+    }
+
     fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<VoidMsg> {
         match action {
             Action::Activate => {
@@ -185,15 +190,15 @@ impl Handler for CheckBox<()> {
             a @ _ => Response::unhandled_action(a),
         }
     }
-
-    #[inline]
-    fn handle(&mut self, tk: &mut dyn TkWindow, _: Address, event: Event) -> Response<Self::Msg> {
-        Manager::handle_activable(self, tk, event)
-    }
 }
 
 impl<M, H: Fn(bool) -> M> Handler for CheckBox<H> {
     type Msg = M;
+
+    #[inline]
+    fn activation_via_press(&self) -> bool {
+        true
+    }
 
     fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<M> {
         match action {
@@ -204,10 +209,5 @@ impl<M, H: Fn(bool) -> M> Handler for CheckBox<H> {
             }
             a @ _ => Response::unhandled_action(a),
         }
-    }
-
-    #[inline]
-    fn handle(&mut self, tk: &mut dyn TkWindow, _: Address, event: Event) -> Response<Self::Msg> {
-        Manager::handle_activable(self, tk, event)
     }
 }

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -5,11 +5,10 @@
 
 //! Toggle widgets
 
-use std::any::TypeId;
 use std::fmt::{self, Debug};
 
 use crate::class::{HasBool, HasText};
-use crate::event::{self, err_unhandled, Action, EmptyMsg, Handler};
+use crate::event::{self, err_unhandled, Action, Handler, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -174,24 +173,24 @@ impl<H> HasText for CheckBox<H> {
 }
 
 impl Handler for CheckBox<()> {
-    type Msg = EmptyMsg;
+    type Msg = VoidMsg;
 
-    fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> EmptyMsg {
+    fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<VoidMsg> {
         match action {
             Action::Activate => {
                 self.state = !self.state;
                 tk.redraw(self.id());
-                EmptyMsg
+                Response::None
             }
             a @ _ => err_unhandled(a),
         }
     }
 }
 
-impl<M: From<EmptyMsg>, H: Fn(bool) -> M> Handler for CheckBox<H> {
+impl<M, H: Fn(bool) -> M> Handler for CheckBox<H> {
     type Msg = M;
 
-    fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> M {
+    fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<M> {
         match action {
             Action::Activate => {
                 self.state = !self.state;

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -8,7 +8,7 @@
 use std::fmt::{self, Debug};
 
 use crate::class::{HasBool, HasText};
-use crate::event::{self, err_unhandled, Action, Handler, Response, VoidMsg};
+use crate::event::{self, unhandled_action, Action, Handler, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -182,7 +182,7 @@ impl Handler for CheckBox<()> {
                 tk.redraw(self.id());
                 Response::None
             }
-            a @ _ => err_unhandled(a),
+            a @ _ => unhandled_action(a),
         }
     }
 }
@@ -197,7 +197,7 @@ impl<M, H: Fn(bool) -> M> Handler for CheckBox<H> {
                 tk.redraw(self.id());
                 ((self.on_toggle)(self.state)).into()
             }
-            a @ _ => err_unhandled(a),
+            a @ _ => unhandled_action(a),
         }
     }
 }

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -8,7 +8,7 @@
 use std::fmt::{self, Debug};
 
 use crate::class::{HasBool, HasText};
-use crate::event::{self, unhandled_action, Action, Handler, Response, VoidMsg};
+use crate::event::{self, Action, Event, EventChild, Handler, Manager, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -182,8 +182,13 @@ impl Handler for CheckBox<()> {
                 tk.redraw(self.id());
                 Response::None
             }
-            a @ _ => unhandled_action(a),
+            a @ _ => Response::Unhandled(EventChild::Action(a)),
         }
+    }
+
+    #[inline]
+    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
+        Manager::handle_activable(self, tk, event)
     }
 }
 
@@ -197,7 +202,12 @@ impl<M, H: Fn(bool) -> M> Handler for CheckBox<H> {
                 tk.redraw(self.id());
                 ((self.on_toggle)(self.state)).into()
             }
-            a @ _ => unhandled_action(a),
+            a @ _ => Response::Unhandled(EventChild::Action(a)),
         }
+    }
+
+    #[inline]
+    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
+        Manager::handle_activable(self, tk, event)
     }
 }

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -8,16 +8,15 @@
 //! KAS dialog boxes are pre-configured windows, usually allowing some
 //! customisation.
 
-use crate::event::{Callback, EmptyMsg};
+use crate::event::{Callback, Response, VoidMsg};
 use crate::geom::Size;
 use crate::layout;
-use crate::macros::{EmptyMsg, Widget};
+use crate::macros::{VoidMsg, Widget};
 use crate::widget::{Label, TextButton};
 use crate::{CoreData, TkAction, TkWindow, Window};
 
-#[derive(Clone, Debug, EmptyMsg)]
+#[derive(Clone, Debug, VoidMsg)]
 enum DialogButton {
-    None,
     Close,
 }
 
@@ -46,12 +45,11 @@ impl MessageBox {
         }
     }
 
-    fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: DialogButton) -> EmptyMsg {
+    fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: DialogButton) -> Response<VoidMsg> {
         match msg {
-            DialogButton::None => (),
             DialogButton::Close => tk.send_action(TkAction::Close),
         };
-        EmptyMsg
+        Response::None
     }
 }
 

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -156,7 +156,7 @@ impl<W: Widget + Handler> Handler for ScrollRegion<W> {
                 }
             }
             Response::Unhandled(Event::PressStart { source, coord }) if source.is_primary() => {
-                tk.update_data(&mut |data| data.request_press_grab(source, self.id(), coord));
+                tk.update_data(&mut |data| data.request_press_grab(source, self, coord));
                 Response::None
             }
             e @ _ => e,

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::Debug;
 
-use crate::event::{EmptyMsg, Event, EventChild, Handler, Manager, ScrollDelta};
+use crate::event::{Event, EventChild, Handler, Manager, Response, ScrollDelta};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{DrawHandle, SizeHandle, TextClass};
@@ -80,7 +80,7 @@ impl<W: Widget> ScrollRegion<W> {
 impl<W: Widget + Handler> Handler for ScrollRegion<W> {
     type Msg = <W as Handler>::Msg;
 
-    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Self::Msg {
+    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
         match event {
             Event::ToChild(id, event) => {
                 // Intercept scroll events.
@@ -97,7 +97,7 @@ impl<W: Widget + Handler> Handler for ScrollRegion<W> {
                         };
                         self.offset = (self.offset + delta).min(Coord::ZERO).max(self.min_offset);
                         tk.redraw(self.id());
-                        EmptyMsg.into()
+                        Response::None
                     }
                     ev @ _ => self.child.handle(tk, Event::ToChild(id, ev)),
                 }

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -132,7 +132,7 @@ impl<W: Widget + Handler> Handler for ScrollRegion<W> {
                     tk.redraw(self.id());
                     Response::None
                 } else {
-                    Response::Unhandled(Event::Action(Action::Scroll(delta)))
+                    Response::unhandled_action(Action::Scroll(delta))
                 }
             }
             e @ _ => e,

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -126,10 +126,12 @@ impl<W: Widget + Handler> Handler for ScrollRegion<W> {
             Event::PressEnd {
                 source,
                 start_id,
+                end_id,
                 coord,
             } => Event::PressEnd {
                 source,
                 start_id,
+                end_id,
                 coord: coord - self.offset,
             },
         };

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -8,7 +8,7 @@
 use std::fmt::{self, Debug};
 
 use crate::class::{Editable, HasText};
-use crate::event::{self, Action, EmptyMsg, Handler};
+use crate::event::{self, Action, Handler, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -300,33 +300,33 @@ impl<H> Editable for EditBox<H> {
 }
 
 impl Handler for EditBox<()> {
-    type Msg = EmptyMsg;
+    type Msg = VoidMsg;
 
-    fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> EmptyMsg {
+    fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<VoidMsg> {
         match action {
             Action::Activate => tk.update_data(&mut |data| data.set_char_focus(self.id())),
             Action::ReceivedCharacter(c) => {
                 self.received_char(tk, c);
             }
         }
-        EmptyMsg
+        Response::None
     }
 }
 
-impl<M: From<EmptyMsg>, H: Fn(&str) -> M> Handler for EditBox<H> {
+impl<M, H: Fn(&str) -> M> Handler for EditBox<H> {
     type Msg = M;
 
-    fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> M {
+    fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<M> {
         match action {
             Action::Activate => {
                 tk.update_data(&mut |data| data.set_char_focus(self.id()));
-                EmptyMsg.into()
+                Response::None
             }
             Action::ReceivedCharacter(c) => {
                 if self.received_char(tk, c) {
                     ((self.on_activate)(&self.text)).into()
                 } else {
-                    EmptyMsg.into()
+                    Response::None
                 }
             }
         }

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -8,7 +8,7 @@
 use std::fmt::{self, Debug};
 
 use crate::class::{Editable, HasText};
-use crate::event::{self, Action, Event, EventChild, Handler, Manager, Response, VoidMsg};
+use crate::event::{self, Action, Address, Event, Handler, Manager, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -312,12 +312,12 @@ impl Handler for EditBox<()> {
                 self.received_char(tk, c);
                 Response::None
             }
-            a @ _ => Response::Unhandled(EventChild::Action(a)),
+            a @ _ => Response::Unhandled(Event::Action(a)),
         }
     }
 
     #[inline]
-    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
+    fn handle(&mut self, tk: &mut dyn TkWindow, _: Address, event: Event) -> Response<Self::Msg> {
         Manager::handle_activable(self, tk, event)
     }
 }
@@ -338,12 +338,12 @@ impl<M, H: Fn(&str) -> M> Handler for EditBox<H> {
                     Response::None
                 }
             }
-            a @ _ => Response::Unhandled(EventChild::Action(a)),
+            a @ _ => Response::Unhandled(Event::Action(a)),
         }
     }
 
     #[inline]
-    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
+    fn handle(&mut self, tk: &mut dyn TkWindow, _: Address, event: Event) -> Response<Self::Msg> {
         Manager::handle_activable(self, tk, event)
     }
 }

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -312,7 +312,7 @@ impl Handler for EditBox<()> {
                 self.received_char(tk, c);
                 Response::None
             }
-            a @ _ => Response::Unhandled(Event::Action(a)),
+            a @ _ => Response::unhandled_action(a),
         }
     }
 
@@ -338,7 +338,7 @@ impl<M, H: Fn(&str) -> M> Handler for EditBox<H> {
                     Response::None
                 }
             }
-            a @ _ => Response::Unhandled(Event::Action(a)),
+            a @ _ => Response::unhandled_action(a),
         }
     }
 

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -8,7 +8,7 @@
 use std::fmt::{self, Debug};
 
 use crate::class::{Editable, HasText};
-use crate::event::{self, Action, Address, Event, Handler, Manager, Response, VoidMsg};
+use crate::event::{self, Action, Handler, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
@@ -302,6 +302,11 @@ impl<H> Editable for EditBox<H> {
 impl Handler for EditBox<()> {
     type Msg = VoidMsg;
 
+    #[inline]
+    fn activation_via_press(&self) -> bool {
+        true
+    }
+
     fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<VoidMsg> {
         match action {
             Action::Activate => {
@@ -315,15 +320,15 @@ impl Handler for EditBox<()> {
             a @ _ => Response::unhandled_action(a),
         }
     }
-
-    #[inline]
-    fn handle(&mut self, tk: &mut dyn TkWindow, _: Address, event: Event) -> Response<Self::Msg> {
-        Manager::handle_activable(self, tk, event)
-    }
 }
 
 impl<M, H: Fn(&str) -> M> Handler for EditBox<H> {
     type Msg = M;
+
+    #[inline]
+    fn activation_via_press(&self) -> bool {
+        true
+    }
 
     fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<M> {
         match action {
@@ -340,10 +345,5 @@ impl<M, H: Fn(&str) -> M> Handler for EditBox<H> {
             }
             a @ _ => Response::unhandled_action(a),
         }
-    }
-
-    #[inline]
-    fn handle(&mut self, tk: &mut dyn TkWindow, _: Address, event: Event) -> Response<Self::Msg> {
-        Manager::handle_activable(self, tk, event)
     }
 }

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::{self, Debug};
 
-use crate::event::{Callback, Event, Handler, Response, VoidMsg};
+use crate::event::{Address, Callback, Event, Handler, Response, VoidMsg};
 use crate::geom::Size;
 use crate::layout::{self};
 use crate::macros::Widget;
@@ -83,9 +83,14 @@ impl<W: Widget> Window<W> {
 impl<W: Widget + Handler<Msg = VoidMsg> + 'static> Handler for Window<W> {
     type Msg = VoidMsg;
 
-    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
+    fn handle(
+        &mut self,
+        tk: &mut dyn TkWindow,
+        addr: Address,
+        event: Event,
+    ) -> Response<Self::Msg> {
         // The window itself doesn't handle events, so we can just pass through
-        self.w.handle(tk, event)
+        self.w.handle(tk, addr, event)
     }
 }
 

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::{self, Debug};
 
-use crate::event::{Callback, EmptyMsg, Event, Handler};
+use crate::event::{Callback, Event, Handler, Response, VoidMsg};
 use crate::geom::Size;
 use crate::layout::{self};
 use crate::macros::Widget;
@@ -80,22 +80,16 @@ impl<W: Widget> Window<W> {
     }
 }
 
-impl<W> Handler for Window<W>
-where
-    W: Widget + Handler<Msg = EmptyMsg> + 'static,
-{
-    type Msg = EmptyMsg;
+impl<W: Widget + Handler<Msg = VoidMsg> + 'static> Handler for Window<W> {
+    type Msg = VoidMsg;
 
-    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> EmptyMsg {
+    fn handle(&mut self, tk: &mut dyn TkWindow, event: Event) -> Response<Self::Msg> {
         // The window itself doesn't handle events, so we can just pass through
         self.w.handle(tk, event)
     }
 }
 
-impl<W> kas::Window for Window<W>
-where
-    W: Widget + Handler<Msg = EmptyMsg> + 'static,
-{
+impl<W: Widget + Handler<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
     fn resize(&mut self, tk: &mut dyn TkWindow, size: Size) {
         layout::solve(self, tk, size);
     }


### PR DESCRIPTION
Fixes #21

~(currently incomplete, but roughly equivalent to previous functionality)~

Addresses both listed issues.

Notably omitted is "flicking" scrollable regions (momentum & drag model), but ~this is strictly internal to the `ScrollRegion` widget thus can easily land later~ this requires support for "animated" widgets.