### PR TITLE
Dynamic window creation

### DIFF
--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -16,6 +16,7 @@ enum Item {
     Button,
     Check(bool),
     Edit(String),
+    Popup,
 }
 
 fn main() -> Result<(), kas_wgpu::Error> {
@@ -37,11 +38,8 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[widget(row=4, col=0)] _ = Label::from("CheckBox"),
             #[widget(row=4, col=1)] _ = CheckBox::new("").state(true)
                 .on_toggle(|check| Item::Check(check)),
-            #[widget(row=5)] _ = Label::from("A"),
-            #[widget(row=6)] _ = Label::from("few"),
-            #[widget(row=7)] _ = Label::from("more"),
-            #[widget(row=8)] _ = Label::from("rows"),
-            #[widget(row=8, col = 1)] _ = TextButton::new("Another button", Item::Button),
+            #[widget(row=8)] _ = Label::from("Child window"),
+            #[widget(row=8, col = 1)] _ = TextButton::new("Open", Item::Popup),
         }
     };
 
@@ -59,13 +57,17 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget(handler = activations)] _ = ScrollRegion::new(widgets),
             }
             impl {
-                fn activations(&mut self, _: &mut dyn TkWindow, item: Item)
+                fn activations(&mut self, tk: &mut dyn TkWindow, item: Item)
                     -> VoidResponse
                 {
                     match item {
                         Item::Button => println!("Clicked!"),
                         Item::Check(b) => println!("Checkbox: {}", b),
                         Item::Edit(s) => println!("Edited: {}", s),
+                        Item::Popup => {
+                            let window = MessageBox::new("Popup", "Hello!");
+                            tk.add_window(Box::new(window));
+                        }
                     };
                     VoidResponse::None
                 }

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -59,6 +59,8 @@ pub struct DrawPipe {
 
 impl DrawPipe {
     /// Construct
+    // TODO: do we want to share state across windows? With glyph_brush this is
+    // not trivial but with our "pipes" it shouldn't be difficult.
     pub fn new<D: theme::Theme<Self>>(
         device: &mut wgpu::Device,
         tex_format: wgpu::TextureFormat,

--- a/kas-wgpu/src/draw/round_pipe.rs
+++ b/kas-wgpu/src/draw/round_pipe.rs
@@ -8,6 +8,8 @@
 use std::f32::consts::FRAC_PI_2;
 use std::mem::size_of;
 
+use lazy_static::lazy_static;
+
 use kas::draw::*;
 use kas::geom::Size;
 
@@ -25,20 +27,22 @@ pub struct RoundPipe {
     passes: Vec<Vec<Vertex>>,
 }
 
+lazy_static! {
+    static ref VS_BYTES: Vec<u32> = super::read_glsl(
+        include_str!("shaders/round.vert"),
+        glsl_to_spirv::ShaderType::Vertex,
+    );
+    static ref FS_BYTES: Vec<u32> = super::read_glsl(
+        include_str!("shaders/round.frag"),
+        glsl_to_spirv::ShaderType::Fragment,
+    );
+}
+
 impl RoundPipe {
     /// Construct
     pub fn new(device: &wgpu::Device, size: Size, light_norm: [f32; 3]) -> Self {
-        let vs_bytes = super::read_glsl(
-            include_str!("shaders/round.vert"),
-            glsl_to_spirv::ShaderType::Vertex,
-        );
-        let fs_bytes = super::read_glsl(
-            include_str!("shaders/round.frag"),
-            glsl_to_spirv::ShaderType::Fragment,
-        );
-
-        let vs_module = device.create_shader_module(&vs_bytes);
-        let fs_module = device.create_shader_module(&fs_bytes);
+        let vs_module = device.create_shader_module(&VS_BYTES);
+        let fs_module = device.create_shader_module(&FS_BYTES);
 
         type Scale = [f32; 2];
         let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];

--- a/kas-wgpu/src/draw/square_pipe.rs
+++ b/kas-wgpu/src/draw/square_pipe.rs
@@ -8,6 +8,8 @@
 use std::f32;
 use std::mem::size_of;
 
+use lazy_static::lazy_static;
+
 use kas::draw::*;
 use kas::geom::Size;
 
@@ -25,20 +27,22 @@ pub struct SquarePipe {
     passes: Vec<Vec<Vertex>>,
 }
 
+lazy_static! {
+    static ref VS_BYTES: Vec<u32> = super::read_glsl(
+        include_str!("shaders/square.vert"),
+        glsl_to_spirv::ShaderType::Vertex,
+    );
+    static ref FS_BYTES: Vec<u32> = super::read_glsl(
+        include_str!("shaders/square.frag"),
+        glsl_to_spirv::ShaderType::Fragment,
+    );
+}
+
 impl SquarePipe {
     /// Construct
     pub fn new(device: &wgpu::Device, size: Size, light_norm: [f32; 3]) -> Self {
-        let vs_bytes = super::read_glsl(
-            include_str!("shaders/square.vert"),
-            glsl_to_spirv::ShaderType::Vertex,
-        );
-        let fs_bytes = super::read_glsl(
-            include_str!("shaders/square.frag"),
-            glsl_to_spirv::ShaderType::Fragment,
-        );
-
-        let vs_module = device.create_shader_module(&vs_bytes);
-        let fs_module = device.create_shader_module(&fs_bytes);
+        let vs_module = device.create_shader_module(&VS_BYTES);
+        let fs_module = device.create_shader_module(&FS_BYTES);
 
         type Scale = [f32; 2];
         let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];

--- a/kas-wgpu/src/lib.rs
+++ b/kas-wgpu/src/lib.rs
@@ -143,6 +143,6 @@ impl<T: kas::theme::Theme<DrawPipe> + 'static, U: 'static> Toolkit<T, U> {
     pub fn run(self) -> ! {
         let mut el = event::Loop::new(self.windows, self.shared);
         self.el
-            .run(move |event, _, control_flow| el.handle(event, control_flow))
+            .run(move |event, elwt, control_flow| el.handle(event, elwt, control_flow))
     }
 }

--- a/src/layout/sizer.rs
+++ b/src/layout/sizer.rs
@@ -63,9 +63,9 @@ pub trait RulesSetter {
 
 /// Solve `widget` for `SizeRules` on both axes, horizontal first.
 pub fn solve<L: Widget>(widget: &mut L, tk: &mut dyn TkWindow, size: Size) {
-    // We call size_rules not because we want the result, but because our
-    // spec requires that we do so before calling set_rect.
     tk.with_size_handle(&mut |size_handle| {
+        // We call size_rules not because we want the result, but because our
+        // spec requires that we do so before calling set_rect.
         let w = widget.size_rules(size_handle, AxisInfo::new(false, None));
         let h = widget.size_rules(size_handle, AxisInfo::new(true, Some(size.0)));
 

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -46,6 +46,15 @@ pub enum TkAction {
 /// event handling. In these cases the user is *always* given an existing
 /// reference to a `TkWindow`. Mostly this trait is only used internally.
 pub trait TkWindow {
+    /// Add a window
+    ///
+    /// Toolkits typically allow windows to be added directly, before start of
+    /// the event loop (e.g. `kas_wgpu::Toolkit::add`).
+    ///
+    /// This method is an alternative allowing a window to be added via event
+    /// processing, albeit without error handling.
+    fn add_window(&mut self, widget: Box<dyn kas::Window>);
+
     /// Read access to the event manager state
     fn data(&self) -> &event::Manager;
 


### PR DESCRIPTION
Allows window creation from event handlers (see #28).

In my testing on X11 it's somewhat slow with debug builds (faster but still not instantaneous with release builds). ~I cannot measure latency > 1ms within the event loop, so I don't think the problem lies within `kas` / `kas_wgpu`.~

Edit: slow window creation was due to redundant shader compilation.