### PR TITLE
Widget::configure, internal_doc, Manager API, use &mut Manager in event handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ repository = "https://github.com/dhardy/kas"
 [features]
 # Enables usage of unstable Rust features
 nightly = []
+# Enables documentation of APIs for toolkits and internal use.
+# This API is not intended for use by end-user applications and
+# thus is omitted from built documentation by default.
+# This flag does not change the API, only built documentation.
+internal_doc = []
 
 [dependencies]
 log = "0.4"
@@ -36,4 +41,4 @@ optional = true
 members = ["kas-macros", "kas-wgpu"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ nightly = []
 
 [dependencies]
 log = "0.4"
+smallvec = "1.1"
 
 [dependencies.kas-macros]
 version = "0.1.0"

--- a/kas-macros/src/layout.rs
+++ b/kas-macros/src/layout.rs
@@ -95,13 +95,13 @@ pub(crate) fn derive(
             fn draw(
                 &self,
                 draw_handle: &mut dyn kas::theme::DrawHandle,
-                ev_mgr: &kas::event::Manager
+                mgr: &kas::event::Manager
             ) {
                 use kas::WidgetCore;
                 if #is_frame {
                     draw_handle.outer_frame(self.core_data().rect);
                 }
-                self.#ident.draw(draw_handle, ev_mgr);
+                self.#ident.draw(draw_handle, mgr);
             }
         };
         let ty = quote! {
@@ -223,7 +223,7 @@ impl<'a> ImplLayout<'a> {
             let c0 = self.#ident.rect().pos;
             let c1 = c0 + Coord::from(self.#ident.rect().size);
             if c0.0 <= pos1.0 && c1.0 >= pos0.0 && c0.1 <= pos1.1 && c1.1 >= pos0.1 {
-                self.#ident.draw(draw_handle, ev_mgr);
+                self.#ident.draw(draw_handle, mgr);
             }
         });
 
@@ -415,7 +415,7 @@ impl<'a> ImplLayout<'a> {
             fn draw(
                 &self,
                 draw_handle: &mut dyn kas::theme::DrawHandle,
-                ev_mgr: &kas::event::Manager
+                mgr: &kas::event::Manager
             ) {
                 use kas::{geom::Coord, WidgetCore};
                 let rect = draw_handle.target_rect();

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -11,10 +11,9 @@ use std::str::FromStr;
 
 use kas::class::HasText;
 use kas::event::VirtualKeyCode as VK;
-use kas::event::{Response, VoidMsg};
+use kas::event::{Manager, Response, VoidMsg};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::{EditBox, TextButton, Window};
-use kas::TkWindow;
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Key {
@@ -78,9 +77,9 @@ fn main() -> Result<(), kas_wgpu::Error> {
             calc: Calculator = Calculator::new(),
         }
         impl {
-            fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: Key) -> Response<VoidMsg> {
+            fn handle_button(&mut self, mgr: &mut Manager, msg: Key) -> Response<VoidMsg> {
                 if self.calc.handle(msg) {
-                    self.display.set_text(tk, self.calc.display());
+                    self.display.set_text(mgr, self.calc.display());
                 }
                 Response::None
             }

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -12,10 +12,9 @@ use chrono::prelude::*;
 use std::time::Duration;
 
 use kas::class::HasText;
-use kas::event::{Callback, VoidMsg};
+use kas::event::{Callback, Manager, VoidMsg};
 use kas::macros::make_widget;
 use kas::widget::{Label, Window};
-use kas::TkWindow;
 
 fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
@@ -29,17 +28,17 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget] time: Label = Label::new("")
             }
             impl {
-                fn on_tick(&mut self, tk: &mut dyn TkWindow) {
+                fn on_tick(&mut self, mgr: &mut Manager) {
                     let now = Local::now();
-                    self.date.set_text(tk, now.format("%Y-%m-%d").to_string());
-                    self.time.set_text(tk, now.format("%H:%M:%S").to_string());
+                    self.date.set_text(mgr, now.format("%Y-%m-%d").to_string());
+                    self.time.set_text(mgr, now.format("%H:%M:%S").to_string());
                 }
             }
         },
     );
 
-    window.add_callback(Callback::Repeat(Duration::from_secs(1)), &|w, tk| {
-        w.on_tick(tk)
+    window.add_callback(Callback::Repeat(Duration::from_secs(1)), &|w, mgr| {
+        w.on_tick(mgr)
     });
 
     let mut theme = kas_wgpu::SampleTheme::new();

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -15,7 +15,7 @@ use kas::class::HasText;
 use kas::event::{Callback, VoidMsg};
 use kas::macros::make_widget;
 use kas::widget::{Label, Window};
-use kas::{TkWindow, WidgetCore};
+use kas::TkWindow;
 
 fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
@@ -31,9 +31,8 @@ fn main() -> Result<(), kas_wgpu::Error> {
             impl {
                 fn on_tick(&mut self, tk: &mut dyn TkWindow) {
                     let now = Local::now();
-                    self.date.set_text(tk, now.format("%Y %m %d").to_string());
+                    self.date.set_text(tk, now.format("%Y-%m-%d").to_string());
                     self.time.set_text(tk, now.format("%H:%M:%S").to_string());
-                    tk.redraw(self.id());
                 }
             }
         },

--- a/kas-wgpu/examples/clock_expanded.rs
+++ b/kas-wgpu/examples/clock_expanded.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use kas::class::HasText;
 use kas::event::Callback;
 use kas::widget::{Label, Window};
-use kas::{TkWindow, WidgetCore};
+use kas::TkWindow;
 
 fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
@@ -36,9 +36,8 @@ fn main() -> Result<(), kas_wgpu::Error> {
         impl AnonWidget {
             fn on_tick(&mut self, tk: &mut dyn TkWindow) {
                 let now = Local::now();
-                self.date.set_text(tk, now.format("%Y %m %d").to_string());
+                self.date.set_text(tk, now.format("%Y-%m-%d").to_string());
                 self.time.set_text(tk, now.format("%H:%M:%S").to_string());
-                tk.redraw(self.id());
             }
         }
         AnonWidget {

--- a/kas-wgpu/examples/clock_expanded.rs
+++ b/kas-wgpu/examples/clock_expanded.rs
@@ -12,9 +12,8 @@ use chrono::prelude::*;
 use std::time::Duration;
 
 use kas::class::HasText;
-use kas::event::Callback;
+use kas::event::{Callback, Manager};
 use kas::widget::{Label, Window};
-use kas::TkWindow;
 
 fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
@@ -34,10 +33,10 @@ fn main() -> Result<(), kas_wgpu::Error> {
             time: Label,
         }
         impl AnonWidget {
-            fn on_tick(&mut self, tk: &mut dyn TkWindow) {
+            fn on_tick(&mut self, mgr: &mut Manager) {
                 let now = Local::now();
-                self.date.set_text(tk, now.format("%Y-%m-%d").to_string());
-                self.time.set_text(tk, now.format("%H:%M:%S").to_string());
+                self.date.set_text(mgr, now.format("%Y-%m-%d").to_string());
+                self.time.set_text(mgr, now.format("%H:%M:%S").to_string());
             }
         }
         AnonWidget {
@@ -48,8 +47,8 @@ fn main() -> Result<(), kas_wgpu::Error> {
         }
     });
 
-    window.add_callback(Callback::Repeat(Duration::from_secs(1)), &|w, tk| {
-        w.on_tick(tk)
+    window.add_callback(Callback::Repeat(Duration::from_secs(1)), &|w, mgr| {
+        w.on_tick(mgr)
     });
 
     let mut theme = kas_wgpu::SampleTheme::new();

--- a/kas-wgpu/examples/counter.rs
+++ b/kas-wgpu/examples/counter.rs
@@ -7,10 +7,9 @@
 #![feature(proc_macro_hygiene)]
 
 use kas::class::HasText;
-use kas::event::{VoidMsg, VoidResponse};
+use kas::event::{Manager, VoidMsg, VoidResponse};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::{Label, TextButton, Window};
-use kas::TkWindow;
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Message {
@@ -38,17 +37,17 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 counter: usize = 0,
             }
             impl {
-                fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: Message)
+                fn handle_button(&mut self, mgr: &mut Manager, msg: Message)
                     -> VoidResponse
                 {
                     match msg {
                         Message::Decr => {
                             self.counter = self.counter.saturating_sub(1);
-                            self.display.set_text(tk, self.counter.to_string());
+                            self.display.set_text(mgr, self.counter.to_string());
                         }
                         Message::Incr => {
                             self.counter = self.counter.saturating_add(1);
-                            self.display.set_text(tk, self.counter.to_string());
+                            self.display.set_text(mgr, self.counter.to_string());
                         }
                     };
                     VoidResponse::None

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -7,10 +7,9 @@
 #![feature(proc_macro_hygiene)]
 
 use kas::class::HasText;
-use kas::event::{Callback, Response, VoidMsg};
+use kas::event::{Callback, Manager, Response, VoidMsg};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::{Column, EditBox, Label, ScrollRegion, TextButton, Window};
-use kas::TkWindow;
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Control {
@@ -37,24 +36,24 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[widget(handler = handler)] _ = TextButton::new("+", Control::Incr),
         }
         impl {
-            fn handler(&mut self, tk: &mut dyn TkWindow, msg: Control) -> Response<Message> {
+            fn handler(&mut self, mgr: &mut Manager, msg: Control) -> Response<Message> {
                 match self.edit.get_text().parse::<usize>() {
                     Ok(mut n) => {
                         match msg {
                             Control::Decr => {
                                 n = n.saturating_sub(1);
-                                self.edit.set_string(tk, n.to_string());
+                                self.edit.set_string(mgr, n.to_string());
                             },
                             Control::Incr => {
                                 n = n.saturating_add(1);
-                                self.edit.set_string(tk, n.to_string());
+                                self.edit.set_string(mgr, n.to_string());
                             },
                             Control::Set => ()
                         }
                         Message::Set(n).into()
                     }
                     _ => {
-                        self.edit.set_string(tk, "0".to_string());
+                        self.edit.set_string(mgr, "0".to_string());
                         Message::Set(0).into()
                     }
                 }
@@ -72,11 +71,11 @@ fn main() -> Result<(), kas_wgpu::Error> {
                     ScrollRegion::new(Column::new(vec![])).with_bars(false, true),
             }
             impl {
-                fn handler(&mut self, tk: &mut dyn TkWindow, msg: Message) -> Response<VoidMsg>
+                fn handler(&mut self, mgr: &mut Manager, msg: Message) -> Response<VoidMsg>
                 {
                     match msg {
                         Message::Set(n) => {
-                            self.list.inner_mut().resize_with(tk, n, |i| EditBox::new(i.to_string()));
+                            self.list.inner_mut().resize_with(mgr, n, |i| EditBox::new(i.to_string()));
                         }
                     };
                     Response::None
@@ -85,8 +84,8 @@ fn main() -> Result<(), kas_wgpu::Error> {
         },
     );
 
-    window.add_callback(Callback::Start, &|w, tk| {
-        let _ = w.handler(tk, Message::Set(3));
+    window.add_callback(Callback::Start, &|w, mgr| {
+        let _ = w.handler(mgr, Message::Set(3));
     });
 
     let theme = kas_wgpu::SampleTheme::new();

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -6,11 +6,10 @@
 //! Gallery of all widgets
 #![feature(proc_macro_hygiene)]
 
-use kas::event::{Response, VoidMsg, VoidResponse};
+use kas::event::{Manager, Response, VoidMsg, VoidResponse};
 use kas::layout::Horizontal;
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::*;
-use kas::TkWindow;
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Item {
@@ -47,7 +46,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[widget(row=8, col = 1)] _ = TextButton::new("Open", Item::Popup),
         }
         impl {
-            fn handle_scroll(&mut self, _: &mut dyn TkWindow, msg: u32) -> Response<Item> {
+            fn handle_scroll(&mut self, _: &mut Manager, msg: u32) -> Response<Item> {
                 Response::Msg(Item::Scroll(msg))
             }
         }
@@ -67,7 +66,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget(handler = activations)] _ = ScrollRegion::new(widgets).with_auto_bars(true),
             }
             impl {
-                fn activations(&mut self, tk: &mut dyn TkWindow, item: Item)
+                fn activations(&mut self, mgr: &mut Manager, item: Item)
                     -> VoidResponse
                 {
                     match item {
@@ -77,7 +76,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                         Item::Scroll(p) => println!("ScrollBar: {}", p),
                         Item::Popup => {
                             let window = MessageBox::new("Popup", "Hello!");
-                            tk.add_window(Box::new(window));
+                            mgr.add_window(Box::new(window));
                         }
                     };
                     VoidResponse::None

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -10,10 +10,9 @@ use std::fmt::Write;
 use std::time::{Duration, Instant};
 
 use kas::class::HasText;
-use kas::event::{Callback, Response, VoidMsg};
+use kas::event::{Callback, Manager, Response, VoidMsg};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::{Label, TextButton, Window};
-use kas::TkWindow;
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Control {
@@ -36,8 +35,8 @@ fn make_window() -> Box<dyn kas::Window> {
                     fn get_text(&self) -> &str {
                         self.display.get_text()
                     }
-                    fn set_string(&mut self, tk: &mut dyn TkWindow, text: String) {
-                        self.display.set_text(tk, text);
+                    fn set_string(&mut self, mgr: &mut Manager, text: String) {
+                        self.display.set_text(mgr, text);
                     }
                 }
             },
@@ -48,12 +47,12 @@ fn make_window() -> Box<dyn kas::Window> {
             dur_buf: String = String::default(),
         }
         impl {
-            fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: Control) -> Response<VoidMsg> {
+            fn handle_button(&mut self, mgr: &mut Manager, msg: Control) -> Response<VoidMsg> {
                 match msg {
                     Control::Reset => {
                         self.saved = Duration::default();
                         self.start = None;
-                        self.display.set_text(tk, "0.000");
+                        self.display.set_text(mgr, "0.000");
                     }
                     Control::Start => {
                         if let Some(start) = self.start {
@@ -67,7 +66,7 @@ fn make_window() -> Box<dyn kas::Window> {
                 Response::None
             }
 
-            fn on_tick(&mut self, tk: &mut dyn TkWindow) {
+            fn on_tick(&mut self, mgr: &mut Manager) {
                 if let Some(start) = self.start {
                     let dur = self.saved + (Instant::now() - start);
                     self.dur_buf.clear();
@@ -76,7 +75,7 @@ fn make_window() -> Box<dyn kas::Window> {
                         dur.as_secs(),
                         dur.subsec_millis()
                     )).unwrap();
-                    self.display.set_text(tk, &self.dur_buf);
+                    self.display.set_text(mgr, &self.dur_buf);
                 }
             }
         }
@@ -84,8 +83,8 @@ fn make_window() -> Box<dyn kas::Window> {
 
     let mut window = Window::new("Stopwatch", stopwatch);
 
-    window.add_callback(Callback::Repeat(Duration::from_millis(16)), &|w, tk| {
-        w.on_tick(tk)
+    window.add_callback(Callback::Repeat(Duration::from_millis(16)), &|w, mgr| {
+        w.on_tick(mgr)
     });
 
     Box::new(window)

--- a/kas-wgpu/examples/theme.rs
+++ b/kas-wgpu/examples/theme.rs
@@ -9,12 +9,11 @@
 use std::cell::Cell;
 
 use kas::draw::Colour;
-use kas::event::{VoidMsg, VoidResponse};
+use kas::event::{Manager, VoidMsg, VoidResponse};
 use kas::geom::Rect;
 use kas::macros::{make_widget, VoidMsg};
 use kas::theme::Theme;
 use kas::widget::*;
-use kas::TkWindow;
 
 use kas_wgpu::draw::*;
 use kas_wgpu::glyph::Font;
@@ -112,7 +111,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget(handler = handler)] _ = widgets,
             }
             impl {
-                fn handler(&mut self, _: &mut dyn TkWindow, item: Item)
+                fn handler(&mut self, _: &mut Manager, item: Item)
                     -> VoidResponse
                 {
                     match item {

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -203,7 +203,9 @@ impl<T: theme::Theme<DrawPipe>> Loop<T> {
                     self.windows.get(&id).map(|w| w.window.request_redraw());
                 }
                 TkAction::Reconfigure => {
-                    self.windows.get_mut(&id).map(|w| w.reconfigure());
+                    if let Some(window) = self.windows.get_mut(&id) {
+                        window.reconfigure(&mut self.shared);
+                    }
                 }
                 TkAction::Close => {
                     if let Some(window) = self.windows.remove(&id) {

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -75,7 +75,7 @@ impl<T> SharedState<T> {
 
     pub fn next_window_id(&mut self) -> WindowId {
         self.window_id += 1;
-        kas::make_window_id(NonZeroU32::new(self.window_id).unwrap())
+        WindowId::new(NonZeroU32::new(self.window_id).unwrap())
     }
 
     #[cfg(not(feature = "clipboard"))]

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -110,6 +110,38 @@ impl<T> SharedState<T> {
     }
 }
 
+// For some implementations this may need to be implemented on a
+// window-specific handle; for us this is unnecessary.
+//
+// NOTE: Correct clipboard handling on Wayland requires a window handle.
+impl<T> kas::TkWindow for SharedState<T> {
+    fn add_window(&mut self, widget: Box<dyn kas::Window>) -> WindowId {
+        // By far the simplest way to implement this is to let our call
+        // anscestor, event::Loop::handle, do the work.
+        //
+        // In theory we could pass the EventLoopWindowTarget for *each* event
+        // handled to create the winit window here or use statics to generate
+        // errors now, but user code can't do much with this error anyway.
+        let id = self.next_window_id();
+        self.pending.push(PendingAction::AddWindow(id, widget));
+        id
+    }
+
+    fn close_window(&mut self, id: WindowId) {
+        self.pending.push(PendingAction::CloseWindow(id));
+    }
+
+    #[inline]
+    fn get_clipboard(&mut self) -> Option<String> {
+        self.get_clipboard()
+    }
+
+    #[inline]
+    fn set_clipboard(&mut self, content: String) {
+        self.set_clipboard(content);
+    }
+}
+
 pub enum PendingAction {
     AddWindow(WindowId, Box<dyn kas::Window>),
     CloseWindow(WindowId),

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -101,9 +101,9 @@ impl<TW: theme::Window<DrawPipe> + 'static> Window<TW> {
         let size = Size(self.sc_desc.width, self.sc_desc.height);
         debug!("Reconfiguring window (size = {:?})", size);
 
-        self.mgr.configure(shared, self.widget.as_widget_mut());
         let mut size_handle = unsafe { self.theme_window.size_handle(&mut self.draw_pipe) };
         self.widget.resize(&mut size_handle, size);
+        self.mgr.configure(shared, &mut *self.widget);
         self.window.request_redraw();
     }
 

--- a/src/class.rs
+++ b/src/class.rs
@@ -5,7 +5,7 @@
 
 //! Class-specific widget traits
 
-use crate::TkWindow;
+use crate::event::Manager;
 
 /// Functionality for widgets which can be toggled or selected: check boxes,
 /// radio buttons, toggle switches.
@@ -16,7 +16,7 @@ pub trait HasBool {
     fn get_bool(&self) -> bool;
 
     /// Set the widget's state
-    fn set_bool(&mut self, tk: &mut dyn TkWindow, state: bool);
+    fn set_bool(&mut self, mgr: &mut Manager, state: bool);
 }
 
 /// Functionality for widgets with visible text.
@@ -30,17 +30,17 @@ pub trait HasText {
     fn get_text(&self) -> &str;
 
     /// Set the widget's text.
-    fn set_text<T: ToString>(&mut self, tk: &mut dyn TkWindow, text: T)
+    fn set_text<T: ToString>(&mut self, mgr: &mut Manager, text: T)
     where
         Self: Sized,
     {
-        self.set_string(tk, text.to_string());
+        self.set_string(mgr, text.to_string());
     }
 
     /// Set the widget's text (string only).
     ///
     /// This method is for implementation.
-    fn set_string(&mut self, tk: &mut dyn TkWindow, text: String);
+    fn set_string(&mut self, mgr: &mut Manager, text: String);
 }
 
 /// Additional functionality required by the `EditBox` widget.

--- a/src/data.rs
+++ b/src/data.rs
@@ -22,11 +22,9 @@ use crate::geom::Rect;
 pub struct WidgetId(NonZeroU32);
 
 impl WidgetId {
-    #[doc(hidden)]
-    pub const FIRST: WidgetId = WidgetId(unsafe { NonZeroU32::new_unchecked(1) });
+    pub(crate) const FIRST: WidgetId = WidgetId(unsafe { NonZeroU32::new_unchecked(1) });
     const LAST: WidgetId = WidgetId(unsafe { NonZeroU32::new_unchecked(u32::MAX) });
 
-    #[doc(hidden)]
     pub(crate) fn next(self) -> Self {
         WidgetId(NonZeroU32::new(self.0.get() + 1).unwrap())
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,7 +9,6 @@ use std::fmt;
 use std::num::NonZeroU32;
 use std::u32;
 
-use crate::event::VirtualKeyCode;
 use crate::geom::Rect;
 
 /// Widget identifier
@@ -58,34 +57,4 @@ impl fmt::Display for WidgetId {
 pub struct CoreData {
     pub rect: Rect,
     pub id: WidgetId,
-    // variable-length list; None may not preceed Some(_)
-    keys: [Option<VirtualKeyCode>; 4],
-}
-
-impl CoreData {
-    /// Set shortcut keys
-    pub fn set_keys(&mut self, keys: &[VirtualKeyCode]) {
-        if keys.len() > self.keys.len() {
-            panic!(
-                "CoreData::set_keys: found {} keys; max supported is {}",
-                keys.len(),
-                self.keys.len()
-            );
-        }
-        for (source, dest) in keys.iter().copied().zip(&mut self.keys) {
-            *dest = Some(source);
-        }
-        for dest in &mut self.keys[keys.len()..] {
-            *dest = None;
-        }
-    }
-
-    /// Get shortcut keys
-    pub fn keys<'a>(&'a self) -> impl Iterator<Item = VirtualKeyCode> + 'a {
-        self.keys
-            .iter()
-            .take_while(|x| x.is_some())
-            .fuse()
-            .map(|x| x.unwrap())
-    }
 }

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -172,7 +172,7 @@ impl<M> Clone for Box<dyn Handler<Msg = M>> {
     }
 }
 
-impl Manager {
+impl<'a> Manager<'a> {
     /// Generic handler for low-level events passed to leaf widgets
     pub fn handle_generic<W>(
         widget: &mut W,

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -98,11 +98,7 @@ impl Manager {
         self.accel_keys.clear();
         widget.walk_mut(&mut |widget| {
             map.insert(widget.id(), id);
-            widget.core_data_mut().id = id;
-
-            for key in widget.core_data().keys() {
-                self.accel_keys.insert(key, id);
-            }
+            widget.configure(id, self);
             id = id.next();
         });
 
@@ -210,6 +206,15 @@ impl Manager {
     fn set_last_mouse_coord(&mut self, coord: Coord) -> bool {
         self.last_mouse_coord = coord;
         false
+    }
+
+    /// Adds an accelerator key for a widget
+    ///
+    /// If this key is pressed when the window has focus and no widget has a
+    /// key-grab, the given widget will receive an [`Action::Activate`] event.
+    #[inline]
+    pub fn add_accel_key(&mut self, key: VirtualKeyCode, id: WidgetId) {
+        self.accel_keys.insert(key, id);
     }
 
     /// Request a mouse grab on the given input source

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -9,7 +9,7 @@ use std::collections::{hash_map::Entry, HashMap};
 
 use super::*;
 use crate::geom::Coord;
-use crate::{TkAction, Widget, WidgetId};
+use crate::{TkAction, TkWindow, Widget, WidgetId, WindowId};
 
 /// Highlighting state of a widget
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
@@ -90,7 +90,7 @@ impl ManagerState {
     ///
     /// This should be called by the toolkit on the widget tree when the window
     /// is created (before or after resizing).
-    pub fn configure(&mut self, widget: &mut dyn Widget) {
+    pub fn configure(&mut self, tkw: &mut dyn TkWindow, widget: &mut dyn Widget) {
         // Re-assigning WidgetIds might invalidate state; to avoid this we map
         // existing ids to new ids
         let mut map = HashMap::new();
@@ -99,7 +99,7 @@ impl ManagerState {
         self.accel_keys.clear();
         widget.walk_mut(&mut |widget| {
             map.insert(widget.id(), id);
-            widget.configure(id, &mut self.manager());
+            widget.configure(id, &mut self.manager(tkw));
             id = id.next();
         });
 
@@ -111,8 +111,8 @@ impl ManagerState {
 
         // TODO: this widget may no longer be under the mouse pointer!
         // We have addr = Address::Coord(self.last_mouse_coord), but cannot use
-        // widget.handle(tk, addr, Event::Identify) because we don't have tk
-        // (and the caller cannot construct this: ev_mgr is already borrowed).
+        // widget.handle(mgr, addr, Event::Identify) because we don't have mgr
+        // (and the caller cannot construct this: mgr is already borrowed).
         // Solution: add some other method to resolve a widget from a coord.
         self.hover = self.hover.and_then(|id| map.get(&id).cloned());
 
@@ -134,10 +134,11 @@ impl ManagerState {
 
     /// Construct a [`Manager`] referring to this state
     #[inline]
-    pub fn manager(&mut self) -> Manager {
+    pub fn manager<'a>(&'a mut self, tkw: &'a mut dyn TkWindow) -> Manager<'a> {
         Manager {
             action: TkAction::None,
             mgr: self,
+            tkw,
         }
     }
 }
@@ -146,19 +147,19 @@ impl ManagerState {
 pub struct Manager<'a> {
     action: TkAction,
     mgr: &'a mut ManagerState,
+    tkw: &'a mut dyn TkWindow,
 }
 
-/// Toolkit API
-#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+/// Public API (around toolkit functionality)
 impl<'a> Manager<'a> {
-    /// Extract the [`TkAction`].
-    pub fn unwrap_action(&mut self) -> TkAction {
-        self.action
+    /// Notify that a widget must be redrawn
+    #[inline]
+    pub fn redraw(&mut self, _id: WidgetId) {
+        // Theoretically, notifying by WidgetId allows selective redrawing
+        // (damage events). This is not yet implemented.
+        self.send_action(TkAction::Redraw);
     }
-}
 
-/// Public API
-impl<'a> Manager<'a> {
     /// Notify that a [`TkAction`] action should happen
     ///
     /// This causes the given action to happen after event handling.
@@ -171,6 +172,42 @@ impl<'a> Manager<'a> {
         self.action = self.action.max(action);
     }
 
+    /// Add a window
+    ///
+    /// Toolkits typically allow windows to be added directly, before start of
+    /// the event loop (e.g. `kas_wgpu::Toolkit::add`).
+    ///
+    /// This method is an alternative allowing a window to be added via event
+    /// processing, albeit without error handling.
+    #[inline]
+    pub fn add_window(&mut self, widget: Box<dyn kas::Window>) -> WindowId {
+        self.tkw.add_window(widget)
+    }
+
+    /// Close a window
+    #[inline]
+    pub fn close_window(&mut self, id: WindowId) {
+        self.tkw.close_window(id);
+    }
+
+    /// Attempt to get clipboard contents
+    ///
+    /// In case of failure, paste actions will simply fail. The implementation
+    /// may wish to log an appropriate warning message.
+    #[inline]
+    pub fn get_clipboard(&mut self) -> Option<String> {
+        self.tkw.get_clipboard()
+    }
+
+    /// Attempt to set clipboard contents
+    #[inline]
+    pub fn set_clipboard(&mut self, content: String) {
+        self.tkw.set_clipboard(content)
+    }
+}
+
+/// Public API (around event manager state)
+impl<'a> Manager<'a> {
     /// Get the complete highlight state
     pub fn highlight_state(&self, w_id: WidgetId) -> HighlightState {
         HighlightState {
@@ -242,13 +279,13 @@ impl<'a> Manager<'a> {
     /// If successful, [`Action::ReceivedCharacter`] events are sent to this
     /// widget when character data is received.
     ///
-    /// Returns true on success. Currently, this method always succeeds.
-    pub fn request_char_focus(&mut self, id: WidgetId) -> bool {
+    /// Currently, this method always succeeds.
+    pub fn request_char_focus(&mut self, id: WidgetId) {
         if self.mgr.key_focus.is_some() {
             self.mgr.key_focus = Some(id);
         }
         self.mgr.char_focus = Some(id);
-        true
+        self.redraw(id);
     }
 
     /// Request a mouse grab on the given `source`
@@ -259,29 +296,24 @@ impl<'a> Manager<'a> {
     /// e.g. the move events are not needed (although in practice this only
     /// affects parents intercepting [`Response::Unhandled`] events).
     ///
-    /// Returns true on success. This method normally succeeds, but fails when
+    /// This method normally succeeds, but fails when
     /// multiple widgets attempt a grab the same press source simultaneously
     /// (only the first grab is successful).
     ///
     /// This method automatically cancels any active char grab
     /// and updates keyboard navigation focus.
-    pub fn request_press_grab(
-        &mut self,
-        source: PressSource,
-        widget: &dyn Widget,
-        coord: Coord,
-    ) -> bool {
+    pub fn request_press_grab(&mut self, source: PressSource, widget: &dyn Widget, coord: Coord) {
         let w_id = widget.id();
         match source {
             PressSource::Mouse(button) => {
                 if self.mgr.mouse_grab.is_none() {
                     self.mgr.mouse_grab = Some((w_id, button));
                 } else {
-                    return false;
+                    return;
                 }
             }
             PressSource::Touch(touch_id) => match self.mgr.touch_grab.entry(touch_id) {
-                Entry::Occupied(_) => return false,
+                Entry::Occupied(_) => return,
                 Entry::Vacant(v) => {
                     v.insert(PressEvent {
                         start_id: w_id,
@@ -299,25 +331,46 @@ impl<'a> Manager<'a> {
             self.mgr.char_focus = None;
         }
 
-        true
+        self.redraw(w_id);
     }
 }
 
 /// Internal methods
 impl<'a> Manager<'a> {
     #[cfg(feature = "winit")]
-    fn set_hover(&mut self, w_id: Option<WidgetId>) -> bool {
+    fn set_hover(&mut self, w_id: Option<WidgetId>) {
         if self.mgr.hover != w_id {
             self.mgr.hover = w_id;
-            return true;
+            self.send_action(TkAction::Redraw);
         }
-        false
     }
 
     #[cfg(feature = "winit")]
-    fn set_last_mouse_coord(&mut self, coord: Coord) -> bool {
-        self.mgr.last_mouse_coord = coord;
-        false
+    fn add_key_event(&mut self, scancode: u32, id: WidgetId) {
+        for item in &self.mgr.key_events {
+            if item.1 == id {
+                return;
+            }
+        }
+
+        self.mgr.key_events.push((scancode, id));
+        self.redraw(id);
+    }
+
+    #[cfg(feature = "winit")]
+    fn remove_key_event(&mut self, scancode: u32) {
+        let r = 'outer: loop {
+            for (i, item) in self.mgr.key_events.iter().enumerate() {
+                // We must match scancode not vkey since the
+                // latter may have changed due to modifiers
+                if item.0 == scancode {
+                    break 'outer i;
+                }
+            }
+            return;
+        };
+        self.redraw(self.mgr.key_events[r].1);
+        self.mgr.key_events.remove(r);
     }
 
     #[cfg(feature = "winit")]
@@ -326,12 +379,12 @@ impl<'a> Manager<'a> {
     }
 
     #[cfg(feature = "winit")]
-    fn end_mouse_grab(&mut self, button: MouseButton) -> bool {
-        if self.mgr.mouse_grab.map(|g| g.1 == button).unwrap_or(false) {
-            self.mgr.mouse_grab = None;
-            true
-        } else {
-            false
+    fn end_mouse_grab(&mut self, button: MouseButton) {
+        if let Some(grab) = self.mgr.mouse_grab {
+            if grab.1 == button {
+                self.mgr.mouse_grab = None;
+                self.redraw(grab.0);
+            }
         }
     }
 
@@ -341,53 +394,68 @@ impl<'a> Manager<'a> {
     }
 
     #[cfg(feature = "winit")]
-    fn update_touch_coord(&mut self, touch_id: u64, coord: Coord) -> bool {
+    fn update_touch_coord(&mut self, touch_id: u64, coord: Coord) {
         if let Some(v) = self.mgr.touch_grab.get_mut(&touch_id) {
             v.last_coord = coord;
-            true
-        } else {
-            false
+            // TODO: update cur_id (currently not calculated)
+            // self.redraw(v.cur_id);
         }
     }
 
     #[cfg(feature = "winit")]
-    fn end_touch_grab(&mut self, touch_id: u64) -> bool {
-        self.mgr.touch_grab.remove(&touch_id).is_some()
+    fn end_touch_grab(&mut self, touch_id: u64) {
+        if let Some(grab) = self.mgr.touch_grab.remove(&touch_id) {
+            self.redraw(grab.cur_id);
+        }
     }
 
     #[cfg(feature = "winit")]
-    fn next_key_focus(&mut self, widget: &mut dyn Widget) -> bool {
-        let start = self.mgr.key_focus;
-        let mut id = start.map(|id| id.next()).unwrap_or(WidgetId::FIRST);
+    fn next_key_focus(&mut self, widget: &mut dyn Widget) {
+        let mut id = self.mgr.key_focus.unwrap_or(WidgetId::FIRST);
         let end = widget.id();
-        while id <= end {
+        loop {
+            id = id.next();
+            if id >= end {
+                return self.unset_key_focus();
+            }
+
             if widget
                 .get_by_id(id)
                 .map(|w| w.allow_focus())
                 .unwrap_or(false)
             {
+                self.send_action(TkAction::Redraw);
                 self.mgr.key_focus = Some(id);
-                return start != Some(id);
+                return;
             }
-            id = id.next();
+        }
+    }
+
+    #[cfg(feature = "winit")]
+    fn unset_key_focus(&mut self) {
+        if let Some(id) = self.mgr.key_focus {
+            self.redraw(id);
         }
         self.mgr.key_focus = None;
-        start != None
     }
 }
 
+/// Toolkit API
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 impl<'a> Manager<'a> {
+    /// Extract the [`TkAction`].
+    pub fn unwrap_action(&mut self) -> TkAction {
+        self.action
+    }
+
     /// Handle a winit `WindowEvent`.
     ///
     /// Note that some event types are not *does not* handled, since for these
     /// events the toolkit must take direct action anyway:
     /// `Resized(size)`, `RedrawRequested`, `HiDpiFactorChanged(factor)`.
     #[cfg(feature = "winit")]
-    pub fn handle_winit<W>(
-        widget: &mut W,
-        tk: &mut dyn crate::TkWindow,
-        event: winit::event::WindowEvent,
-    ) where
+    pub fn handle_winit<W>(mut self, widget: &mut W, event: winit::event::WindowEvent) -> TkAction
+    where
         W: Widget + Handler<Msg = VoidMsg> + ?Sized,
     {
         use log::trace;
@@ -398,7 +466,7 @@ impl<'a> Manager<'a> {
             // Resized(size) [handled by toolkit]
             // Moved(position)
             CloseRequested => {
-                tk.send_action(TkAction::Close);
+                self.send_action(TkAction::Close);
                 Response::None
             }
             // Destroyed
@@ -406,94 +474,57 @@ impl<'a> Manager<'a> {
             // HoveredFile(PathBuf),
             // HoveredFileCancelled,
             ReceivedCharacter(c) if c != '\u{1b}' /* escape */ => {
-                if let Some(id) = tk.data().mgr.char_focus {
+                if let Some(id) = self.mgr.char_focus {
                     let ev = Event::Action(Action::ReceivedCharacter(c));
-                    widget.handle(tk, Address::Id(id), ev)
+                    widget.handle(&mut self, Address::Id(id), ev)
                 } else {
                     Response::None
                 }
             }
             // Focused(bool),
             KeyboardInput { input, .. } => {
-                let char_focus = tk.data().mgr.char_focus.is_some();
+                let char_focus = self.mgr.char_focus.is_some();
                 match (input.scancode, input.state, input.virtual_keycode) {
                     (_, ElementState::Pressed, Some(vkey)) if char_focus => match vkey {
                         VirtualKeyCode::Escape => {
-                            tk.update_data(&mut |data| {
-                                data.mgr.char_focus = None;
-                                true
-                            });
+                            if let Some(id) = self.mgr.char_focus {
+                                self.redraw(id);
+                            }
+                            self.mgr.char_focus = None;
                             Response::None
                         }
                         _ => Response::None,
                     },
                     (scancode, ElementState::Pressed, Some(vkey)) if !char_focus => match vkey {
                         VirtualKeyCode::Tab => {
-                            tk.update_data(&mut |data| data.next_key_focus(widget.as_widget_mut()));
+                            self.next_key_focus(widget.as_widget_mut());
                             Response::None
                         }
                         VirtualKeyCode::Return | VirtualKeyCode::NumpadEnter => {
-                            if let Some(id) = tk.data().mgr.key_focus {
-                                let ev = Event::Action(Action::Activate);
-                                let r =  widget.handle(tk, Address::Id(id), ev);
-
+                            if let Some(id) = self.mgr.key_focus {
                                 // Add to key_events for visual feedback
-                                tk.update_data(&mut |data| {
-                                    for item in &data.mgr.key_events {
-                                        if item.1 == id {
-                                            return false;
-                                        }
-                                    }
-                                    data.mgr.key_events.push((scancode, id));
-                                    true
-                                });
-                                r
+                                self.add_key_event(scancode, id);
+
+                                let ev = Event::Action(Action::Activate);
+                                widget.handle(&mut self, Address::Id(id), ev)
                             } else { Response::None }
                         }
                         VirtualKeyCode::Escape => {
-                            tk.update_data(&mut |data| {
-                                if data.mgr.key_focus.is_some() {
-                                    data.mgr.key_focus = None;
-                                    true
-                                } else {
-                                    false
-                                }
-                            });
+                            self.unset_key_focus();
                             Response::None
                         }
                         vkey @ _ => {
-                            if let Some(id) = tk.data().mgr.accel_keys.get(&vkey).cloned() {
-                                let ev = Event::Action(Action::Activate);
-                                let r =  widget.handle(tk, Address::Id(id), ev);
+                            if let Some(id) = self.mgr.accel_keys.get(&vkey).cloned() {
+                                // Add to key_events for visual feedback
+                                self.add_key_event(scancode, id);
 
-                                tk.update_data(&mut |data| {
-                                    for item in &data.mgr.key_events {
-                                        if item.1 == id {
-                                            return false;
-                                        }
-                                    }
-                                    data.mgr.key_events.push((scancode, id));
-                                    true
-                                });
-                                r
+                                let ev = Event::Action(Action::Activate);
+                                widget.handle(&mut self, Address::Id(id), ev)
                             } else { Response::None }
                         }
                     },
                     (scancode, ElementState::Released, _) => {
-                        tk.update_data(&mut |data| {
-                            let r = 'outer: loop {
-                                for (i, item) in data.mgr.key_events.iter().enumerate() {
-                                    // We must match scancode not vkey since the
-                                    // latter may have changed due to modifiers
-                                    if item.0 == scancode {
-                                        break 'outer i;
-                                    }
-                                }
-                                return false;
-                            };
-                            data.mgr.key_events.remove(r);
-                            true
-                        });
+                        self.remove_key_event(scancode);
                         Response::None
                     }
                     _ => Response::None,
@@ -506,38 +537,38 @@ impl<'a> Manager<'a> {
                 let coord = position.into();
 
                 // Update hovered widget
-                let w_id = match widget.handle(tk, Address::Coord(coord), Event::Identify) {
+                let w_id = match widget.handle(&mut self, Address::Coord(coord), Event::Identify) {
                     Response::Identify(w_id) => Some(w_id),
                     _ => None,
                 };
-                tk.update_data(&mut |data| data.set_hover(w_id));
+                self.set_hover(w_id);
 
-                let r = if let Some((grab_id, button)) = tk.data().mouse_grab() {
+                let r = if let Some((grab_id, button)) = self.mouse_grab() {
                     let source = PressSource::Mouse(button);
-                    let delta = coord - tk.data().mgr.last_mouse_coord;
+                    let delta = coord - self.mgr.last_mouse_coord;
                     let ev = Event::PressMove { source, coord, delta };
-                    widget.handle(tk, Address::Id(grab_id), ev)
+                    widget.handle(&mut self, Address::Id(grab_id), ev)
                 } else {
                     // We don't forward move events without a grab
                     Response::None
                 };
 
-                tk.update_data(&mut |data| data.set_last_mouse_coord(coord));
+                self.mgr.last_mouse_coord = coord;
                 r
             }
             // CursorEntered { .. },
             CursorLeft { .. } => {
-                tk.update_data(&mut |data| data.set_hover(None));
+                self.set_hover(None);
                 Response::None
             }
             MouseWheel { delta, .. } => {
                 let action = Action::Scroll(match delta {
                     MouseScrollDelta::LineDelta(x, y) => ScrollDelta::LineDelta(x, y),
                     MouseScrollDelta::PixelDelta(pos) =>
-                        ScrollDelta::PixelDelta(Coord::from_logical(pos, tk.data().mgr.dpi_factor)),
+                        ScrollDelta::PixelDelta(Coord::from_logical(pos, self.mgr.dpi_factor)),
                 });
-                if let Some(id) = tk.data().mgr.hover {
-                    widget.handle(tk, Address::Id(id), Event::Action(action))
+                if let Some(id) = self.mgr.hover {
+                    widget.handle(&mut self, Address::Id(id), Event::Action(action))
                 } else {
                     Response::None
                 }
@@ -547,10 +578,10 @@ impl<'a> Manager<'a> {
                 button,
                 ..
             } => {
-                let coord = tk.data().mgr.last_mouse_coord;
+                let coord = self.mgr.last_mouse_coord;
                 let source = PressSource::Mouse(button);
 
-                let r = if let Some((grab_id, _)) = tk.data().mouse_grab() {
+                let r = if let Some((grab_id, _)) = self.mouse_grab() {
                     // Mouse grab active: send events there
                     let ev = match state {
                         // TODO: using grab_id as start_id is incorrect when
@@ -559,12 +590,12 @@ impl<'a> Manager<'a> {
                         ElementState::Released => Event::PressEnd {
                             source,
                             start_id: Some(grab_id),
-                            end_id: tk.data().mgr.hover,
+                            end_id: self.mgr.hover,
                             coord,
                         },
                     };
-                    widget.handle(tk, Address::Id(grab_id), ev)
-                } else if let Some(id) = tk.data().mgr.hover {
+                    widget.handle(&mut self, Address::Id(grab_id), ev)
+                } else if let Some(id) = self.mgr.hover {
                     // No mouse grab, but we have a hover target
                     let ev = match state {
                         ElementState::Pressed => Event::PressStart { source, coord },
@@ -575,14 +606,14 @@ impl<'a> Manager<'a> {
                             coord,
                         },
                     };
-                    widget.handle(tk, Address::Id(id), ev)
+                    widget.handle(&mut self, Address::Id(id), ev)
                 } else {
                     // This happens when there is no widget and on click-release
                     // when the cursor is no longer over the window.
                     Response::None
                 };
                 if state == ElementState::Released {
-                    tk.update_data(&mut |data| data.end_mouse_grab(button));
+                    self.end_mouse_grab(button);
                 }
                 r
             }
@@ -595,32 +626,32 @@ impl<'a> Manager<'a> {
                 match touch.phase {
                     TouchPhase::Started => {
                         let ev = Event::PressStart { source, coord };
-                        widget.handle(tk, Address::Coord(coord), ev)
+                        widget.handle(&mut self, Address::Coord(coord), ev)
                     }
                     TouchPhase::Moved => {
-                        if let Some(PressEvent { start_id, last_coord, .. }) = tk.data().touch_grab(touch.id) {
+                        if let Some(PressEvent { start_id, last_coord, .. }) = self.touch_grab(touch.id) {
                             let action = Event::PressMove {
                                 source,
                                 coord,
                                 delta: coord - last_coord,
                             };
-                            let r = widget.handle(tk, Address::Id(start_id), action);
-                            tk.update_data(&mut |data| data.update_touch_coord(touch.id, coord));
+                            let r = widget.handle(&mut self, Address::Id(start_id), action);
+                            self.update_touch_coord(touch.id, coord);
                             r
                         } else {
                             Response::None
                         }
                     }
                     TouchPhase::Ended => {
-                        if let Some(PressEvent { start_id, cur_id, .. }) = tk.data().touch_grab(touch.id) {
+                        if let Some(PressEvent { start_id, cur_id, .. }) = self.touch_grab(touch.id) {
                             let action = Event::PressEnd {
                                 source,
                                 start_id: Some(start_id),
                                 end_id: Some(cur_id),
                                 coord,
                             };
-                            let r = widget.handle(tk, Address::Id(start_id), action);
-                            tk.update_data(&mut |data| data.end_touch_grab(touch.id));
+                            let r = widget.handle(&mut self, Address::Id(start_id), action);
+                            self.end_touch_grab(touch.id);
                             r
                         } else {
                             let action = Event::PressEnd {
@@ -629,19 +660,19 @@ impl<'a> Manager<'a> {
                                 end_id: None,
                                 coord,
                             };
-                            widget.handle(tk, Address::Coord(coord), action)
+                            widget.handle(&mut self, Address::Coord(coord), action)
                         }
                     }
                     TouchPhase::Cancelled => {
-                        if let Some(PressEvent { start_id, .. }) = tk.data().touch_grab(touch.id) {
+                        if let Some(PressEvent { start_id, .. }) = self.touch_grab(touch.id) {
                             let action = Event::PressEnd {
                                 source,
                                 start_id: Some(start_id),
                                 end_id: None,
                                 coord,
                             };
-                            let r = widget.handle(tk, Address::Id(start_id), action);
-                            tk.update_data(&mut |data| data.end_touch_grab(touch.id));
+                            let r = widget.handle(&mut self, Address::Id(start_id), action);
+                            self.end_touch_grab(touch.id);
                             r
                         } else {
                             Response::None
@@ -660,5 +691,7 @@ impl<'a> Manager<'a> {
             }
             Response::Msg(_) => unreachable!(),
         };
+
+        self.unwrap_action()
     }
 }

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -485,10 +485,10 @@ impl<'a> Manager<'a> {
                 }
             }
             // Focused(bool),
-            KeyboardInput { input, .. } => {
+            KeyboardInput { input, is_synthetic, .. } => {
                 let char_focus = self.mgr.char_focus.is_some();
                 match (input.scancode, input.state, input.virtual_keycode) {
-                    (_, ElementState::Pressed, Some(vkey)) if char_focus => match vkey {
+                    (_, ElementState::Pressed, Some(vkey)) if char_focus && !is_synthetic => match vkey {
                         VirtualKeyCode::Escape => {
                             if let Some(id) = self.mgr.char_focus {
                                 self.redraw(id);
@@ -498,7 +498,7 @@ impl<'a> Manager<'a> {
                         }
                         _ => Response::None,
                     },
-                    (scancode, ElementState::Pressed, Some(vkey)) if !char_focus => match vkey {
+                    (scancode, ElementState::Pressed, Some(vkey)) if !char_focus && !is_synthetic => match vkey {
                         VirtualKeyCode::Tab => {
                             self.next_key_focus(widget.as_widget_mut());
                             Response::None

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -12,7 +12,6 @@ use crate::geom::Coord;
 use crate::{Widget, WidgetId};
 
 /// Highlighting state of a widget
-#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 pub struct HighlightState {
     /// "Hover" is true if the mouse is over this element or if an active touch
@@ -65,11 +64,12 @@ pub struct Manager {
     accel_keys: HashMap<VirtualKeyCode, WidgetId>,
 }
 
+/// Toolkit API
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 impl Manager {
     /// Construct an event manager per-window data struct
     ///
     /// The DPI factor may be required for event coordinate translation.
-    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[inline]
     pub fn new(dpi_factor: f64) -> Self {
         Manager {
@@ -89,7 +89,6 @@ impl Manager {
     ///
     /// This should be called by the toolkit on the widget tree when the window
     /// is created (before or after resizing).
-    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     pub fn configure(&mut self, widget: &mut dyn Widget) {
         // Re-assigning WidgetIds might invalidate state; to avoid this we map
         // existing ids to new ids
@@ -127,12 +126,14 @@ impl Manager {
 
     /// Set the DPI factor. Must be updated for correct event translation by
     /// [`Manager::handle_winit`].
-    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[inline]
     pub fn set_dpi_factor(&mut self, dpi_factor: f64) {
         self.dpi_factor = dpi_factor;
     }
+}
 
+/// Public API
+impl Manager {
     /// Get the complete highlight state
     pub fn highlight_state(&self, w_id: WidgetId) -> HighlightState {
         HighlightState {
@@ -187,21 +188,6 @@ impl Manager {
                 return true;
             }
         }
-        false
-    }
-
-    #[cfg(feature = "winit")]
-    fn set_hover(&mut self, w_id: Option<WidgetId>) -> bool {
-        if self.hover != w_id {
-            self.hover = w_id;
-            return true;
-        }
-        false
-    }
-
-    #[cfg(feature = "winit")]
-    fn set_last_mouse_coord(&mut self, coord: Coord) -> bool {
-        self.last_mouse_coord = coord;
         false
     }
 
@@ -277,6 +263,24 @@ impl Manager {
         }
 
         true
+    }
+}
+
+/// Internal methods
+impl Manager {
+    #[cfg(feature = "winit")]
+    fn set_hover(&mut self, w_id: Option<WidgetId>) -> bool {
+        if self.hover != w_id {
+            self.hover = w_id;
+            return true;
+        }
+        false
+    }
+
+    #[cfg(feature = "winit")]
+    fn set_last_mouse_coord(&mut self, coord: Coord) -> bool {
+        self.last_mouse_coord = coord;
+        false
     }
 
     #[cfg(feature = "winit")]

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -12,6 +12,7 @@ use crate::geom::Coord;
 use crate::{Widget, WidgetId};
 
 /// Highlighting state of a widget
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 pub struct HighlightState {
     /// "Hover" is true if the mouse is over this element or if an active touch
@@ -67,9 +68,8 @@ pub struct Manager {
 impl Manager {
     /// Construct an event manager per-window data struct
     ///
-    /// (For toolkit use.)
-    ///
     /// The DPI factor may be required for event coordinate translation.
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[inline]
     pub fn new(dpi_factor: f64) -> Self {
         Manager {
@@ -89,6 +89,7 @@ impl Manager {
     ///
     /// This should be called by the toolkit on the widget tree when the window
     /// is created (before or after resizing).
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     pub fn configure(&mut self, widget: &mut dyn Widget) {
         // Re-assigning WidgetIds might invalidate state; to avoid this we map
         // existing ids to new ids
@@ -126,6 +127,7 @@ impl Manager {
 
     /// Set the DPI factor. Must be updated for correct event translation by
     /// [`Manager::handle_winit`].
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[inline]
     pub fn set_dpi_factor(&mut self, dpi_factor: f64) {
         self.dpi_factor = dpi_factor;
@@ -195,11 +197,6 @@ impl Manager {
             return true;
         }
         false
-    }
-
-    #[inline]
-    pub fn last_mouse_coord(&self) -> Coord {
-        self.last_mouse_coord
     }
 
     #[cfg(feature = "winit")]
@@ -469,7 +466,7 @@ impl Manager {
 
                 let r = if let Some((grab_id, button)) = tk.data().mouse_grab() {
                     let source = PressSource::Mouse(button);
-                    let delta = coord - tk.data().last_mouse_coord();
+                    let delta = coord - tk.data().last_mouse_coord;
                     let ev = Event::PressMove { source, coord, delta };
                     widget.handle(tk, Address::Id(grab_id), ev)
                 } else {
@@ -502,7 +499,7 @@ impl Manager {
                 button,
                 ..
             } => {
-                let coord = tk.data().last_mouse_coord();
+                let coord = tk.data().last_mouse_coord;
                 let source = PressSource::Mouse(button);
 
                 let r = if let Some((grab_id, _)) = tk.data().mouse_grab() {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -73,7 +73,7 @@ pub use callback::Callback;
 pub use enums::{MouseButton, VirtualKeyCode};
 pub use events::*;
 pub use handler::Handler;
-pub use manager::{HighlightState, Manager};
+pub use manager::{HighlightState, Manager, ManagerState};
 pub use response::Response;
 
 /// A void message

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -119,12 +119,12 @@ impl SizeRules {
         self.a = self.a.min(min);
     }
 
-    #[doc(hidden)]
     /// Solve a sequence of rules
     ///
     /// Given a sequence of width / height `rules` from children (including a
     /// final value which is the total) and a `target` size, find an appropriate
     /// size for each child width / height.
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     // TODO (const generics):
     // fn solve_seq<const N: usize>(out: &mut [u32; N], rules: &[Self; N + 1], target: u32)
     pub fn solve_seq(out: &mut [u32], rules: &[Self], target: u32) {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -106,7 +106,7 @@
 //! -   `handler = ...` — the name (`f`) of a method defined on this type which
 //!     handles a message from the child (type `M`) and converts it to the
 //!     appropriate response type for this widget (`R`); this method should have
-//!     signature `fn f(&mut self, tk: &TkWindow, msg: M) -> R`.
+//!     signature `fn f(&mut self, mgr: &mut Manager, msg: M) -> R`.
 //!
 //!
 //! ### Examples
@@ -130,9 +130,9 @@
 //! A longer example, including derivation of the [`Handler`] trait:
 //!
 //! ```
-//! use kas::event::{Handler, VoidResponse, VoidMsg};
+//! use kas::event::{Handler, Manager, VoidResponse, VoidMsg};
 //! use kas::macros::Widget;
-//! use kas::{CoreData, LayoutData, TkWindow, Widget};
+//! use kas::{CoreData, LayoutData, Widget};
 //!
 //! #[derive(Debug)]
 //! enum ChildMessage { A }
@@ -147,7 +147,7 @@
 //! }
 //!
 //! impl<W: Widget> MyWidget<W> {
-//!     fn handler(&mut self, tk: &dyn TkWindow, msg: ChildMessage) -> VoidResponse {
+//!     fn handler(&mut self, mgr: &mut Manager, msg: ChildMessage) -> VoidResponse {
 //!         match msg {
 //!             ChildMessage::A => { println!("handling ChildMessage::A"); }
 //!         }
@@ -208,7 +208,7 @@
 //!
 //! Optionally, a message handler may be specified for child widgets via
 //! `#[widget(handler = f)] ident = value` where `f` is a method defined on the
-//! anonymous struct with signature `fn f(&mut self, tk: &TkWindow, msg: M) -> R`
+//! anonymous struct with signature `fn f(&mut self, mgr: &mut Manager, msg: M) -> R`
 //! where `M` is the type of response received from the child widget, and `R` is
 //! the type of response sent from this widget.
 //!

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -25,7 +25,7 @@ use crate::{event, WidgetId};
 pub struct WindowId(NonZeroU32);
 
 // Only for toolkit use!
-#[doc(hidden)]
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 pub fn make_window_id(n: NonZeroU32) -> WindowId {
     WindowId(n)
 }

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -24,10 +24,14 @@ use crate::{event, WidgetId};
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct WindowId(NonZeroU32);
 
-// Only for toolkit use!
-#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
-pub fn make_window_id(n: NonZeroU32) -> WindowId {
-    WindowId(n)
+impl WindowId {
+    /// Construct a [`WindowId`]
+    ///
+    /// Only for toolkit use!
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+    pub fn new(n: NonZeroU32) -> WindowId {
+        WindowId(n)
+    }
 }
 
 /// Toolkit actions needed after event handling, if any.

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -16,8 +16,6 @@
 
 use std::num::NonZeroU32;
 
-use crate::{event, WidgetId};
-
 /// Identifier for a window added to a toolkit
 ///
 /// Identifiers should always be unique.
@@ -42,7 +40,7 @@ pub enum TkAction {
     None,
     /// Whole window requires redrawing
     ///
-    /// Note that [`TkWindow::redraw`] can instead be used for more selective
+    /// Note that [`Manager::redraw`] can instead be used for more selective
     /// redrawing, if supported by the toolkit.
     Redraw,
     /// Whole window requires reconfiguring (implies redrawing)
@@ -59,10 +57,6 @@ pub enum TkAction {
 /// Toolkit-specific window management and style interface.
 ///
 /// This is implemented by a KAS toolkit on a window handle.
-///
-/// Users interact with this trait in a few cases, such as implementing widget
-/// event handling. In these cases the user is *always* given an existing
-/// reference to a `TkWindow`. Mostly this trait is only used internally.
 pub trait TkWindow {
     /// Add a window
     ///
@@ -75,26 +69,6 @@ pub trait TkWindow {
 
     /// Close a window
     fn close_window(&mut self, id: WindowId);
-
-    /// Read access to the event manager state
-    fn data(&self) -> &event::Manager;
-
-    /// Update event manager data with a closure
-    ///
-    /// The closure should return true if this update may require a redraw.
-    fn update_data(&mut self, f: &mut dyn FnMut(&mut event::Manager) -> bool);
-
-    /// Notify that a widget must be redrawn
-    fn redraw(&mut self, id: WidgetId);
-
-    /// Notify that a toolkit action should happen
-    ///
-    /// This causes the given action to happen after event handling.
-    ///
-    /// Whenever a widget is added, removed or replaced, a reconfigure action is
-    /// required. Should a widget's size requirements change, these will only
-    /// affect the UI after a reconfigure action.
-    fn send_action(&mut self, action: TkAction);
 
     /// Attempt to get clipboard contents
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -40,7 +40,7 @@ pub trait WidgetCore: fmt::Debug {
     /// Get mutable access to the [`CoreData`] providing property storage.
     ///
     /// This should not normally be needed by user code.
-    #[doc(hidden)]
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     fn core_data_mut(&mut self) -> &mut CoreData;
 
     /// Get the widget's numeric identifier

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -197,6 +197,18 @@ impl WidgetCore for Box<dyn Widget> {
 ///
 /// [`Handler`]: crate::event::Handler
 pub trait Widget: WidgetCore {
+    /// Configure widget
+    ///
+    /// Widgets are *configured* on window creation and when
+    /// [`kas::TkAction::Reconfigure`] is sent.
+    ///
+    /// *All* implementations *must* set `self.core.id` to the given `id`.
+    /// Widgets only need to implement this manually when they need to perform
+    /// additional configuration.
+    fn configure(&mut self, id: WidgetId, _mgr: &mut event::Manager) {
+        self.core_data_mut().id = id;
+    }
+
     /// Is this widget navigable via Tab key?
     fn allow_focus(&self) -> bool {
         false

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -9,11 +9,11 @@ use smallvec::SmallVec;
 use std::fmt::Debug;
 
 use crate::class::HasText;
-use crate::event::{self, Action, Handler, Response, VirtualKeyCode};
+use crate::event::{Action, Handler, Manager, Response, VirtualKeyCode};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
-use crate::{CoreData, TkWindow, Widget, WidgetCore, WidgetId};
+use crate::{CoreData, Widget, WidgetCore, WidgetId};
 use kas::geom::Rect;
 
 /// A push-button with a text label
@@ -29,7 +29,7 @@ pub struct TextButton<M: Clone + Debug> {
 }
 
 impl<M: Clone + Debug> Widget for TextButton<M> {
-    fn configure(&mut self, id: WidgetId, mgr: &mut event::Manager) {
+    fn configure(&mut self, id: WidgetId, mgr: &mut Manager) {
         self.core_data_mut().id = id;
         for key in &self.keys {
             mgr.add_accel_key(*key, id);
@@ -55,8 +55,8 @@ impl<M: Clone + Debug> Widget for TextButton<M> {
         self.core_data_mut().rect = rect;
     }
 
-    fn draw(&self, draw_handle: &mut dyn DrawHandle, ev_mgr: &event::Manager) {
-        draw_handle.button(self.core.rect, ev_mgr.highlight_state(self.id()));
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &Manager) {
+        draw_handle.button(self.core.rect, mgr.highlight_state(self.id()));
         let props = TextProperties {
             class: TextClass::Button,
             multi_line: false,
@@ -106,9 +106,9 @@ impl<M: Clone + Debug> HasText for TextButton<M> {
         &self.label
     }
 
-    fn set_string(&mut self, tk: &mut dyn TkWindow, text: String) {
+    fn set_string(&mut self, mgr: &mut Manager, text: String) {
         self.label = text;
-        tk.redraw(self.id());
+        mgr.redraw(self.id());
     }
 }
 
@@ -120,7 +120,7 @@ impl<M: Clone + Debug> Handler for TextButton<M> {
         true
     }
 
-    fn handle_action(&mut self, _: &mut dyn TkWindow, action: Action) -> Response<M> {
+    fn handle_action(&mut self, _: &mut Manager, action: Action) -> Response<M> {
         match action {
             Action::Activate => self.msg.clone().into(),
             a @ _ => Response::unhandled_action(a),

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -5,6 +5,7 @@
 
 //! Push-buttons
 
+use smallvec::SmallVec;
 use std::fmt::Debug;
 
 use crate::class::HasText;
@@ -12,7 +13,7 @@ use crate::event::{self, Action, Handler, Response, VirtualKeyCode};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
-use crate::{CoreData, TkWindow, Widget, WidgetCore};
+use crate::{CoreData, TkWindow, Widget, WidgetCore, WidgetId};
 use kas::geom::Rect;
 
 /// A push-button with a text label
@@ -21,12 +22,20 @@ use kas::geom::Rect;
 pub struct TextButton<M: Clone + Debug> {
     #[core]
     core: CoreData,
+    keys: SmallVec<[VirtualKeyCode; 4]>,
     text_rect: Rect,
     label: String,
     msg: M,
 }
 
 impl<M: Clone + Debug> Widget for TextButton<M> {
+    fn configure(&mut self, id: WidgetId, mgr: &mut event::Manager) {
+        self.core_data_mut().id = id;
+        for key in &self.keys {
+            mgr.add_accel_key(*key, id);
+        }
+    }
+
     fn allow_focus(&self) -> bool {
         true
     }
@@ -68,6 +77,7 @@ impl<M: Clone + Debug> TextButton<M> {
     pub fn new<S: Into<String>>(label: S, msg: M) -> Self {
         TextButton {
             core: Default::default(),
+            keys: SmallVec::new(),
             text_rect: Default::default(),
             label: label.into(),
             msg,
@@ -87,7 +97,7 @@ impl<M: Clone + Debug> TextButton<M> {
 
     /// Set accelerator keys
     pub fn set_keys(&mut self, keys: &[VirtualKeyCode]) {
-        self.core.set_keys(keys);
+        self.keys = SmallVec::from_slice(keys);
     }
 }
 

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -8,11 +8,11 @@
 use std::fmt::{self, Debug};
 
 use crate::class::{HasBool, HasText};
-use crate::event::{self, Action, Handler, Response, VoidMsg};
+use crate::event::{Action, Handler, Manager, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
-use crate::{CoreData, TkWindow, Widget, WidgetCore};
+use crate::{CoreData, Widget, WidgetCore};
 use kas::geom::{Coord, Rect};
 
 /// A checkable box with optional label
@@ -67,8 +67,8 @@ impl<OT: 'static> Widget for CheckBox<OT> {
         self.core_data_mut().rect = rect;
     }
 
-    fn draw(&self, draw_handle: &mut dyn DrawHandle, ev_mgr: &event::Manager) {
-        let highlights = ev_mgr.highlight_state(self.id());
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &Manager) {
+        let highlights = mgr.highlight_state(self.id());
         draw_handle.checkbox(self.box_pos, self.state, highlights);
         let mut text_rect = self.core.rect;
         text_rect.pos.0 = self.text_pos_x;
@@ -156,7 +156,7 @@ impl<H> HasBool for CheckBox<H> {
         self.state
     }
 
-    fn set_bool(&mut self, _tk: &mut dyn TkWindow, state: bool) {
+    fn set_bool(&mut self, _: &mut Manager, state: bool) {
         self.state = state;
     }
 }
@@ -166,9 +166,9 @@ impl<H> HasText for CheckBox<H> {
         &self.label
     }
 
-    fn set_string(&mut self, tk: &mut dyn TkWindow, text: String) {
+    fn set_string(&mut self, mgr: &mut Manager, text: String) {
         self.label = text;
-        tk.redraw(self.id());
+        mgr.redraw(self.id());
     }
 }
 
@@ -180,11 +180,11 @@ impl Handler for CheckBox<()> {
         true
     }
 
-    fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<VoidMsg> {
+    fn handle_action(&mut self, mgr: &mut Manager, action: Action) -> Response<VoidMsg> {
         match action {
             Action::Activate => {
                 self.state = !self.state;
-                tk.redraw(self.id());
+                mgr.redraw(self.id());
                 Response::None
             }
             a @ _ => Response::unhandled_action(a),
@@ -200,11 +200,11 @@ impl<M, H: Fn(bool) -> M> Handler for CheckBox<H> {
         true
     }
 
-    fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<M> {
+    fn handle_action(&mut self, mgr: &mut Manager, action: Action) -> Response<M> {
         match action {
             Action::Activate => {
                 self.state = !self.state;
-                tk.redraw(self.id());
+                mgr.redraw(self.id());
                 ((self.on_toggle)(self.state)).into()
             }
             a @ _ => Response::unhandled_action(a),

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -8,13 +8,13 @@
 //! KAS dialog boxes are pre-configured windows, usually allowing some
 //! customisation.
 
-use crate::event::{Callback, Response, VoidMsg};
+use crate::event::{Callback, Manager, Response, VoidMsg};
 use crate::geom::Size;
 use crate::layout;
 use crate::macros::{VoidMsg, Widget};
 use crate::theme::SizeHandle;
 use crate::widget::{Label, TextButton};
-use crate::{CoreData, TkAction, TkWindow, Window};
+use crate::{CoreData, TkAction, Window};
 
 #[derive(Clone, Debug, VoidMsg)]
 enum DialogButton {
@@ -48,9 +48,9 @@ impl MessageBox {
         }
     }
 
-    fn handle_button(&mut self, tk: &mut dyn TkWindow, msg: DialogButton) -> Response<VoidMsg> {
+    fn handle_button(&mut self, mgr: &mut Manager, msg: DialogButton) -> Response<VoidMsg> {
         match msg {
-            DialogButton::Close => tk.send_action(TkAction::Close),
+            DialogButton::Close => mgr.send_action(TkAction::Close),
         };
         Response::None
     }
@@ -69,8 +69,8 @@ impl Window for MessageBox {
     fn callbacks(&self) -> Vec<(usize, Callback)> {
         Vec::new()
     }
-    fn final_callback(&self) -> Option<&'static dyn Fn(Box<dyn kas::Window>, &mut dyn TkWindow)> {
+    fn final_callback(&self) -> Option<&'static dyn Fn(Box<dyn kas::Window>, &mut Manager)> {
         None
     }
-    fn trigger_callback(&mut self, _index: usize, _tk: &mut dyn TkWindow) {}
+    fn trigger_callback(&mut self, _index: usize, _: &mut Manager) {}
 }

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -310,7 +310,7 @@ impl Handler for EditBox<()> {
     fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<VoidMsg> {
         match action {
             Action::Activate => {
-                tk.update_data(&mut |data| data.set_char_focus(self.id()));
+                tk.update_data(&mut |data| data.request_char_focus(self.id()));
                 Response::None
             }
             Action::ReceivedCharacter(c) => {
@@ -333,7 +333,7 @@ impl<M, H: Fn(&str) -> M> Handler for EditBox<H> {
     fn handle_action(&mut self, tk: &mut dyn TkWindow, action: Action) -> Response<M> {
         match action {
             Action::Activate => {
-                tk.update_data(&mut |data| data.set_char_focus(self.id()));
+                tk.update_data(&mut |data| data.request_char_focus(self.id()));
                 Response::None
             }
             Action::ReceivedCharacter(c) => {


### PR DESCRIPTION
Various changes motived by changing how animated widgets get updated (#35; still not implemented):

- add `fn configure` to `Widget` trait
- add `internal_doc` feature to hide doc aimed at toolkits / internal use by default
- replace `kas_wgpu::TkWindow` struct with `kas::event::Manager` struct and revise `Manager` / `ManagerState` API; cleans up internals a bit
- fix a couple of minor bugs