### PR TITLE
Implement inter-window update

### DIFF
--- a/kas-macros/src/args.rs
+++ b/kas-macros/src/args.rs
@@ -486,6 +486,7 @@ pub struct MakeWidget {
     pub handler_msg: Type,
     // additional attributes
     pub extra_attrs: TokenStream,
+    pub generics: Generics,
     // child widgets and data fields
     pub fields: Vec<WidgetField>,
     // impl blocks on the widget
@@ -519,6 +520,12 @@ impl Parse for MakeWidget {
         };
 
         let _: Struct = input.parse()?;
+
+        let mut generics: syn::Generics = input.parse()?;
+        if input.peek(syn::token::Where) {
+            generics.where_clause = Some(input.parse()?);
+        }
+
         let content;
         let _ = braced!(content in input);
         let mut fields = vec![];
@@ -556,6 +563,7 @@ impl Parse for MakeWidget {
         Ok(MakeWidget {
             handler_msg,
             extra_attrs,
+            generics,
             fields,
             impls,
         })

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -37,10 +37,10 @@ fn main() -> Result<(), kas_wgpu::Error> {
         impl Widget for Clock {
             fn configure(&mut self, id: WidgetId, mgr: &mut Manager) {
                 self.core_data_mut().id = id;
-                mgr.schedule_update(Duration::new(0, 0), id);
+                mgr.update_on_timer(Duration::new(0, 0), id);
             }
 
-            fn update(&mut self, mgr: &mut Manager) -> Option<Duration> {
+            fn update_timer(&mut self, mgr: &mut Manager) -> Option<Duration> {
                 let now = Local::now();
                 self.date.set_text(mgr, now.format("%Y-%m-%d").to_string());
                 self.time.set_text(mgr, now.format("%H:%M:%S").to_string());

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use kas::class::HasText;
 use kas::event::Manager;
 use kas::widget::{Label, Window};
-use kas::{Widget, WidgetCore, WidgetId};
+use kas::{Widget, WidgetCore};
 
 fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
@@ -35,9 +35,8 @@ fn main() -> Result<(), kas_wgpu::Error> {
             time: Label,
         }
         impl Widget for Clock {
-            fn configure(&mut self, id: WidgetId, mgr: &mut Manager) {
-                self.core_data_mut().id = id;
-                mgr.update_on_timer(Duration::new(0, 0), id);
+            fn configure(&mut self, mgr: &mut Manager) {
+                mgr.update_on_timer(Duration::new(0, 0), self.id());
             }
 
             fn update_timer(&mut self, mgr: &mut Manager) -> Option<Duration> {

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -64,7 +64,7 @@ fn make_window() -> Box<dyn kas::Window> {
                             self.start = None;
                         } else {
                             self.start = Some(Instant::now());
-                            mgr.schedule_update(Duration::new(0, 0), self.id());
+                            mgr.update_on_timer(Duration::new(0, 0), self.id());
                         }
                     }
                 }
@@ -72,7 +72,7 @@ fn make_window() -> Box<dyn kas::Window> {
             }
         }
         impl Widget {
-            fn update(&mut self, mgr: &mut Manager) -> Option<Duration> {
+            fn update_timer(&mut self, mgr: &mut Manager) -> Option<Duration> {
                 if let Some(start) = self.start {
                     let dur = self.saved + (Instant::now() - start);
                     self.dur_buf.clear();

--- a/kas-wgpu/examples/sync-counter.rs
+++ b/kas-wgpu/examples/sync-counter.rs
@@ -12,7 +12,7 @@ use kas::class::HasText;
 use kas::event::{Manager, UpdateHandle, VoidMsg, VoidResponse};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::{Label, TextButton, Window};
-use kas::{Widget, WidgetCore, WidgetId};
+use kas::{Widget, WidgetCore};
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Message {
@@ -51,9 +51,8 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 handle: UpdateHandle = handle,
             }
             impl Widget {
-                fn configure(&mut self, id: WidgetId, mgr: &mut Manager) {
-                    self.core_data_mut().id = id;
-                    mgr.update_on_handle(self.handle, id);
+                fn configure(&mut self, mgr: &mut Manager) {
+                    mgr.update_on_handle(self.handle, self.id());
                 }
 
                 fn update_handle(&mut self, mgr: &mut Manager, _: UpdateHandle) {

--- a/kas-wgpu/examples/sync-counter.rs
+++ b/kas-wgpu/examples/sync-counter.rs
@@ -1,0 +1,75 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! A counter synchronised between multiple windows
+#![feature(proc_macro_hygiene)]
+
+use std::cell::RefCell;
+
+use kas::class::HasText;
+use kas::event::{Manager, VoidMsg, VoidResponse};
+use kas::macros::{make_widget, VoidMsg};
+use kas::widget::{Label, TextButton, Window};
+
+#[derive(Clone, Debug, VoidMsg)]
+enum Message {
+    Decr,
+    Incr,
+}
+
+thread_local! {
+    // Save ourselves usage of thread-safe primitives by keeping to a single thread.
+    static COUNTER: RefCell<i32> = RefCell::new(0);
+}
+
+fn main() -> Result<(), kas_wgpu::Error> {
+    env_logger::init();
+
+    let buttons = make_widget! {
+        #[widget]
+        #[layout(horizontal)]
+        #[handler(msg = Message)]
+        struct {
+            #[widget] _ = TextButton::new("−", Message::Decr),
+            #[widget] _ = TextButton::new("+", Message::Incr),
+        }
+    };
+    let window = Window::new(
+        "Counter",
+        make_widget! {
+            #[widget]
+            #[layout(vertical)]
+            #[handler(msg = VoidMsg)]
+            struct {
+                #[widget] display: Label = Label::from("0"),
+                #[widget(handler = handle_button)] buttons -> Message = buttons,
+            }
+            impl {
+                fn handle_button(&mut self, mgr: &mut Manager, msg: Message)
+                    -> VoidResponse
+                {
+                    // TODO: this needs to notify the other window to update itself
+                    let c = COUNTER.with(|c| {
+                        let mut c = c.borrow_mut();
+                        *c += match msg {
+                            Message::Decr => -1,
+                            Message::Incr => 1,
+                        };
+                        *c
+                    });
+                    self.display.set_text(mgr, c.to_string());
+                    VoidResponse::None
+                }
+            }
+        },
+    );
+
+    let mut theme = kas_wgpu::SampleTheme::new();
+    theme.set_font_size(24.0);
+    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
+    toolkit.add(window.clone())?;
+    toolkit.add(window)?;
+    toolkit.run()
+}

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -184,7 +184,7 @@ impl<T: theme::Theme<DrawPipe>> Loop<T> {
             }
         }
 
-        for (id, action) in actions.pop() {
+        while let Some((id, action)) = actions.pop() {
             match action {
                 TkAction::None => (),
                 TkAction::Redraw => {

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -114,7 +114,7 @@ impl<T: theme::Theme<DrawPipe>> Loop<T> {
                         assert_eq!(item.0, requested_resume);
 
                         let resume = if let Some(w) = self.windows.get_mut(&item.1) {
-                            let (action, resume) = w.update(&mut self.shared);
+                            let (action, resume) = w.update_timer(&mut self.shared);
                             actions.push((item.1, action));
                             resume
                         } else {
@@ -179,6 +179,12 @@ impl<T: theme::Theme<DrawPipe>> Loop<T> {
                 PendingAction::CloseWindow(id) => {
                     if let Some(id) = self.id_map.get(&id) {
                         actions.push((*id, TkAction::Close));
+                    }
+                }
+                PendingAction::Update(handle) => {
+                    for (id, window) in self.windows.iter_mut() {
+                        let action = window.update_handle(&mut self.shared, handle);
+                        actions.push((*id, action));
                     }
                 }
             }

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -95,6 +95,9 @@ impl<T: theme::Theme<DrawPipe>> Loop<T> {
                         actions.push((*id, TkAction::CloseAll));
                     }
                 }
+                ProxyAction::Update(handle) => {
+                    self.shared.pending.push(PendingAction::Update(handle));
+                }
             },
 
             NewEvents(cause) => {

--- a/kas-wgpu/src/lib.rs
+++ b/kas-wgpu/src/lib.rs
@@ -14,6 +14,7 @@ mod window;
 
 use std::{error, fmt};
 
+use kas::event::UpdateHandle;
 use kas::WindowId;
 use winit::error::OsError;
 use winit::event_loop::{EventLoop, EventLoopProxy};
@@ -160,10 +161,18 @@ impl ToolkitProxy {
             .send_event(ProxyAction::CloseAll)
             .map_err(|_| ClosedError)
     }
+
+    /// Trigger an update handle
+    pub fn trigger_update(&self, handle: UpdateHandle) -> Result<(), ClosedError> {
+        self.proxy
+            .send_event(ProxyAction::Update(handle))
+            .map_err(|_| ClosedError)
+    }
 }
 
 #[derive(Debug)]
 enum ProxyAction {
     CloseAll,
     Close(WindowId),
+    Update(UpdateHandle),
 }

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -10,6 +10,7 @@ use std::num::NonZeroU32;
 
 use crate::draw::ShaderManager;
 use crate::{Error, WindowId};
+use kas::event::UpdateHandle;
 
 #[cfg(feature = "clipboard")]
 use clipboard::{ClipboardContext, ClipboardProvider};
@@ -131,6 +132,10 @@ impl<T> kas::TkWindow for SharedState<T> {
         self.pending.push(PendingAction::CloseWindow(id));
     }
 
+    fn trigger_update(&mut self, handle: UpdateHandle) {
+        self.pending.push(PendingAction::Update(handle));
+    }
+
     #[inline]
     fn get_clipboard(&mut self) -> Option<String> {
         self.get_clipboard()
@@ -145,4 +150,5 @@ impl<T> kas::TkWindow for SharedState<T> {
 pub enum PendingAction {
     AddWindow(WindowId, Box<dyn kas::Window>),
     CloseWindow(WindowId),
+    Update(UpdateHandle),
 }

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -75,6 +75,7 @@ impl<TW: theme::Window<DrawPipe> + 'static> Window<TW> {
     ///
     /// `init` should always return an action of at least `TkAction::Reconfigure`.
     pub fn init<T>(&mut self, shared: &mut SharedState<T>) -> TkAction {
+        debug!("Window::init");
         let mut mgr = self.mgr.manager(shared);
         mgr.send_action(TkAction::Reconfigure);
 

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -8,7 +8,7 @@
 use log::{debug, info, trace};
 use std::time::Instant;
 
-use kas::event::{Callback, ManagerState};
+use kas::event::{Callback, ManagerState, UpdateHandle};
 use kas::geom::{Coord, Rect, Size};
 use kas::{theme, TkAction};
 use winit::dpi::PhysicalSize;
@@ -151,10 +151,20 @@ impl<TW: theme::Window<DrawPipe> + 'static> Window<TW> {
         mgr.unwrap_action()
     }
 
-    pub(crate) fn update<T>(&mut self, shared: &mut SharedState<T>) -> (TkAction, Option<Instant>) {
+    pub fn update_timer<T>(&mut self, shared: &mut SharedState<T>) -> (TkAction, Option<Instant>) {
         let mut mgr = self.mgr.manager(shared);
-        mgr.update_widgets(&mut *self.widget);
+        mgr.update_timer(&mut *self.widget);
         (mgr.unwrap_action(), self.mgr.next_resume())
+    }
+
+    pub fn update_handle<T>(
+        &mut self,
+        shared: &mut SharedState<T>,
+        handle: UpdateHandle,
+    ) -> TkAction {
+        let mut mgr = self.mgr.manager(shared);
+        mgr.update_handle(handle, &mut *self.widget);
+        mgr.unwrap_action()
     }
 }
 

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -5,11 +5,13 @@
 
 //! Event handling - handler
 
-use crate::event::{Action, Address, Event, Manager, Response};
+use std::time::Duration;
+
+use crate::event::{Action, Address, Event, Manager, Response, UpdateHandle};
 use crate::geom::Rect;
 use crate::layout::{AxisInfo, SizeRules};
 use crate::theme::{DrawHandle, SizeHandle};
-use crate::{CoreData, Layout, Widget, WidgetCore, WidgetId};
+use crate::{CoreData, Layout, Widget, WidgetCore};
 
 /// Event-handling aspect of a widget.
 ///
@@ -84,8 +86,16 @@ impl<M> Handler for Box<dyn Handler<Msg = M>> {
 }
 
 impl<M> Widget for Box<dyn Handler<Msg = M>> {
-    fn configure(&mut self, id: WidgetId, mgr: &mut Manager) {
-        self.as_mut().configure(id, mgr);
+    fn configure(&mut self, mgr: &mut Manager) {
+        self.as_mut().configure(mgr);
+    }
+
+    fn update_timer(&mut self, mgr: &mut Manager) -> Option<Duration> {
+        self.as_mut().update_timer(mgr)
+    }
+
+    fn update_handle(&mut self, mgr: &mut Manager, handle: UpdateHandle) {
+        self.as_mut().update_handle(mgr, handle);
     }
 
     fn allow_focus(&self) -> bool {

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -119,7 +119,8 @@ impl ManagerState {
         let mut mgr = self.manager(tkw);
         widget.walk_mut(&mut |widget| {
             map.insert(widget.id(), id);
-            widget.configure(id, &mut mgr);
+            widget.core_data_mut().id = id;
+            widget.configure(&mut mgr);
             id = id.next();
         });
 

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -61,6 +61,7 @@ mod events;
 mod handler;
 mod manager;
 mod response;
+mod update;
 
 use std::fmt::Debug;
 // use std::path::PathBuf;
@@ -75,6 +76,7 @@ pub use events::*;
 pub use handler::Handler;
 pub use manager::{HighlightState, Manager, ManagerState};
 pub use response::Response;
+pub use update::UpdateHandle;
 
 /// A void message
 ///

--- a/src/event/update.rs
+++ b/src/event/update.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Event handling: updates
+
+use std::num::NonZeroU32;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// An update handle
+///
+/// Update handles are used to trigger an update event on all widgets which are
+/// subscribed to the same handle.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct UpdateHandle(NonZeroU32);
+
+impl UpdateHandle {
+    /// Issue a new [`UpdateHandle`]
+    ///
+    /// A total of 2<sup>32</sup> - 1 update handles are available.
+    /// Attempting to issue 2<sup>32</sup> handles will result in a panic.
+    pub fn new() -> UpdateHandle {
+        static COUNT: AtomicU32 = AtomicU32::new(0);
+
+        loop {
+            let c = COUNT.load(Ordering::Relaxed);
+            let h = c.wrapping_add(1);
+            let nz = NonZeroU32::new(h).unwrap_or_else(|| {
+                panic!("UpdateHandle::new: all available handles have been issued")
+            });
+            if COUNT.compare_and_swap(c, h, Ordering::Relaxed) == c {
+                break UpdateHandle(nz);
+            }
+        }
+    }
+}

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -64,6 +64,7 @@ pub enum TkAction {
 /// Toolkit-specific window management and style interface.
 ///
 /// This is implemented by a KAS toolkit on a window handle.
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 pub trait TkWindow {
     /// Add a window
     ///

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -16,6 +16,8 @@
 
 use std::num::NonZeroU32;
 
+use crate::event::UpdateHandle;
+
 /// Identifier for a window added to a toolkit
 ///
 /// Identifiers should always be unique.
@@ -74,6 +76,12 @@ pub trait TkWindow {
 
     /// Close a window
     fn close_window(&mut self, id: WindowId);
+
+    /// Updates all subscribed widgets
+    ///
+    /// All widgets subscribed to the given [`UpdateHandle`], across all
+    /// windows, will receive an update.
+    fn trigger_update(&mut self, handle: UpdateHandle);
 
     /// Attempt to get clipboard contents
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -8,7 +8,7 @@
 use std::fmt;
 use std::time::Duration;
 
-use crate::event::{Callback, Handler, Manager, VoidMsg};
+use crate::event::{Callback, Handler, Manager, UpdateHandle, VoidMsg};
 use crate::geom::{Rect, Size};
 use crate::layout::{self, AxisInfo, SizeRules};
 use crate::theme::{DrawHandle, SizeHandle};
@@ -273,20 +273,31 @@ pub trait Widget: Layout {
         self.core_data_mut().id = id;
     }
 
-    /// Update the widget
+    /// Update the widget via a timer
     ///
-    /// This method is called on scheduled updates: see [`schedule_update`].
+    /// This method is called on scheduled updates (see [`update_on_timer`]).
     ///
-    /// When some [`Duration`] is returned, another update is scheduled as if
-    /// [`schedule_update`] were called with this duration.
-    /// Required: `duration > 0`.
+    /// When some [`Duration`] is returned, another timed update is scheduled
+    /// at approximately this duration from now (but without blocking redraws;
+    /// usage of 1ns effectively enables per-frame update with FPS limited via
+    /// VSync). Required: `duration > 0`.
     ///
     /// This method being called does not imply a redraw.
     ///
-    /// [`schedule_update`]: Manager::schedule_update
-    fn update(&mut self, _: &mut Manager) -> Option<Duration> {
+    /// [`update_on_timer`]: Manager::update_on_timer
+    fn update_timer(&mut self, _: &mut Manager) -> Option<Duration> {
         None
     }
+
+    /// Update the widget via an update handle
+    ///
+    /// This method is called on triggered updates (see [`update_on_handle`]).
+    /// The source handle is specified via the [`UpdateHandle`] parameter.
+    ///
+    /// This method being called does not imply a redraw.
+    ///
+    /// [`update_on_handle`]: Manager::update_on_handle
+    fn update_handle(&mut self, _: &mut Manager, _: UpdateHandle) {}
 
     /// Is this widget navigable via Tab key?
     fn allow_focus(&self) -> bool {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -266,12 +266,8 @@ pub trait Widget: Layout {
     /// Widgets are *configured* on window creation and when
     /// [`kas::TkAction::Reconfigure`] is sent.
     ///
-    /// *All* implementations *must* set `self.core.id` to the given `id`.
-    /// Widgets only need to implement this manually when they need to perform
-    /// additional configuration.
-    fn configure(&mut self, id: WidgetId, _: &mut Manager) {
-        self.core_data_mut().id = id;
-    }
+    /// This method is called immediately after assigning `self.core_data().id`.
+    fn configure(&mut self, _: &mut Manager) {}
 
     /// Update the widget via a timer
     ///

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -13,7 +13,7 @@ use crate::event::{Action, Handler, Manager, Response, VirtualKeyCode};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::theme::{Align, DrawHandle, SizeHandle, TextClass, TextProperties};
-use crate::{CoreData, Layout, Widget, WidgetCore, WidgetId};
+use crate::{CoreData, Layout, Widget, WidgetCore};
 use kas::geom::Rect;
 
 /// A push-button with a text label
@@ -28,10 +28,9 @@ pub struct TextButton<M: Clone + Debug> {
 }
 
 impl<M: Clone + Debug> Widget for TextButton<M> {
-    fn configure(&mut self, id: WidgetId, mgr: &mut Manager) {
-        self.core_data_mut().id = id;
+    fn configure(&mut self, mgr: &mut Manager) {
         for key in &self.keys {
-            mgr.add_accel_key(*key, id);
+            mgr.add_accel_key(*key, self.id());
         }
     }
 


### PR DESCRIPTION
Implements the remainder of #37.

Also some fixes:

- allows generics in `make_widget!` macro
- sets `cur_id` for touch grabs (re-enables highlighting as a side-effect)
- corrects mapping of WidgetId in configure