### PR TITLE
Extend draw traits; improve theme rendering

### DIFF
--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -38,13 +38,13 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[widget(row=2, col=0)] _ = Label::from("TextButton"),
             #[widget(row=2, col=1)] _ = TextButton::new("Press me", Item::Button),
             #[widget(row=3, col=0)] _ = Label::from("CheckBox"),
-            #[widget(row=3, col=1)] _ = CheckBox::new("Check me")
+            #[widget(row=3, col=1)] _ = CheckBox::new("Check me").state(true)
                 .on_toggle(|check| Item::Check(check)),
             #[widget(row=4, col=0)] _ = Label::from("RadioBox"),
-            #[widget(row=4, col=1)] _ = RadioBox::new(radio, "radio box 1").state(true)
+            #[widget(row=4, col=1)] _ = RadioBox::new(radio, "radio box 1").state(false)
                 .on_activate(|id| Item::Radio(id)),
             #[widget(row=5, col=0)] _ = Label::from("RadioBox"),
-            #[widget(row=5, col=1)] _ = RadioBox::new(radio, "radio box 2")
+            #[widget(row=5, col=1)] _ = RadioBox::new(radio, "radio box 2").state(true)
                 .on_activate(|id| Item::Radio(id)),
             #[widget(row=6, col=0)] _ = Label::from("ScrollBar"),
             #[widget(row=6, col=1, handler = handle_scroll)] _ =

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -34,6 +34,19 @@ pub enum ShadeStyle {
 
 /// Abstraction over drawing commands specific to `kas_wgpu`
 pub trait DrawExt: Draw {
+    /// Add a line with rounded ends to the draw buffer
+    ///
+    /// Note that for rectangular, axis-aligned lines, [`Draw::rect`] should be
+    /// preferred.
+    fn rounded_line(
+        &mut self,
+        region: Self::Region,
+        p1: Coord,
+        p2: Coord,
+        radius: f32,
+        col: Colour,
+    );
+
     /// Add a flat circle to the draw buffer
     ///
     /// More generally, this shape is an axis-aligned oval.
@@ -196,6 +209,11 @@ impl Draw for DrawPipe {
 }
 
 impl DrawExt for DrawPipe {
+    #[inline]
+    fn rounded_line(&mut self, pass: usize, p1: Coord, p2: Coord, radius: f32, col: Colour) {
+        self.flat_round.line(pass, p1, p2, radius, col);
+    }
+
     #[inline]
     fn circle(&mut self, pass: usize, rect: Rect, inner_radius: f32, col: Colour) {
         self.flat_round.circle(pass, rect, inner_radius, col);

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -34,14 +34,24 @@ pub enum ShadeStyle {
 
 /// Abstraction over drawing commands specific to `kas_wgpu`
 pub trait DrawExt: Draw {
+    /// Add a flat circle to the draw buffer
+    ///
+    /// More generally, this shape is an axis-aligned oval.
+    ///
+    /// The `inner_radius` parameter gives the inner radius relative to the
+    /// outer radius: a value of `0.0` will result in the whole shape being
+    /// painted, while `1.0` will result in a zero-width line on the outer edge.
+    fn circle(&mut self, region: Self::Region, rect: Rect, inner_radius: f32, col: Colour);
+
     /// Add a rounded flat frame to the draw buffer.
     ///
     /// All drawing occurs within the `outer` rect and outside of the `inner`
     /// rect. Corners are circular (or more generally, ovular), centered on the
-    /// inner corners. The `inner_radius` parameter gives the inner radius
-    /// relative to the outer radius: a value of `0.0` will result in the whole
-    /// region (within the rounded corners) being painted, while `1.0` will
-    /// result in a zero-width line on the outer edge.
+    /// inner corners.
+    ///
+    /// The `inner_radius` parameter gives the inner radius relative to the
+    /// outer radius: a value of `0.0` will result in the whole shape being
+    /// painted, while `1.0` will result in a zero-width line on the outer edge.
     fn rounded_frame(
         &mut self,
         region: Self::Region,
@@ -183,6 +193,11 @@ impl Draw for DrawPipe {
 }
 
 impl DrawExt for DrawPipe {
+    #[inline]
+    fn circle(&mut self, pass: usize, rect: Rect, inner_radius: f32, col: Colour) {
+        self.flat_round.circle(pass, rect, inner_radius, col);
+    }
+
     #[inline]
     fn rounded_frame(
         &mut self,

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -20,13 +20,13 @@ use kas::theme;
 pub enum ShadeStyle {
     /// Square corners, shading according to the given normals
     ///
-    /// Normal has two components, `(outer, inner)`, interpreted as the
+    /// Normal has two components, `(inner, outer)`, interpreted as the
     /// horizontal component of the direction vector outwards from the drawn
     /// feature. Both values are constrained to the closed range `[-1, 1]`.
     Square(Vec2),
     /// Round corners, shading according to the given normals
     ///
-    /// Normal has two components, `(outer, inner)`, interpreted as the
+    /// Normal has two components, `(inner, outer)`, interpreted as the
     /// horizontal component of the direction vector outwards from the drawn
     /// feature. Both values are constrained to the closed range `[-1, 1]`.
     Round(Vec2),
@@ -60,6 +60,9 @@ pub trait DrawExt: Draw {
         inner_radius: f32,
         col: Colour,
     );
+
+    /// Add a shaded square/circle to the draw buffer
+    fn shaded_box(&mut self, region: Self::Region, rect: Rect, style: ShadeStyle, col: Colour);
 
     /// Add a rounded shaded frame to the draw buffer.
     fn shaded_frame(
@@ -209,6 +212,14 @@ impl DrawExt for DrawPipe {
     ) {
         self.flat_round
             .rounded_frame(pass, outer, inner, inner_radius, col);
+    }
+
+    #[inline]
+    fn shaded_box(&mut self, pass: usize, rect: Rect, style: ShadeStyle, col: Colour) {
+        match style {
+            ShadeStyle::Square(norm) => self.shaded_square.shaded_rect(pass, rect, norm, col),
+            ShadeStyle::Round(norm) => self.shaded_round.circle(pass, rect, norm, col),
+        }
     }
 
     #[inline]

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -9,38 +9,10 @@ use std::f32;
 use wgpu_glyph::{GlyphCruncher, HorizontalAlign, Layout, Scale, Section, VerticalAlign};
 
 use crate::draw::{DrawPipe, Vec2};
-use kas::draw::Colour;
+use kas::draw::{Colour, DrawText};
 use kas::geom::{Coord, Rect};
 use kas::theme::{TextClass, TextProperties};
 use kas::Align;
-
-/// Abstraction over text rendering
-///
-/// Note: the current API is designed to meet only current requirements since
-/// changes are expected to support external font shaping libraries.
-pub trait DrawText {
-    /// Simple text drawing
-    ///
-    /// This allows text to be drawn according to a high-level API, and should
-    /// satisfy most uses.
-    fn text(&mut self, rect: Rect, text: &str, font_scale: f32, props: TextProperties, col: Colour);
-
-    /// Calculate size bound on text
-    ///
-    /// This may be used with [`DrawText::text`] to calculate size requirements
-    /// within [`kas::Layout::size_rules`].
-    ///
-    /// Bounds of `(f32::INFINITY, f32::INFINITY)` may be used if there are no
-    /// constraints. This parameter allows forcing line-wrapping behaviour
-    /// within the given bounds.
-    fn text_bound(
-        &mut self,
-        text: &str,
-        font_scale: f32,
-        bounds: (f32, f32),
-        line_wrap: bool,
-    ) -> (f32, f32);
-}
 
 impl DrawText for DrawPipe {
     fn text(

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -5,56 +5,110 @@
 
 //! Text drawing API for `kas_wgpu`
 
-use std::borrow::Cow;
-use wgpu_glyph::{GlyphCruncher, VariedSection};
+use std::f32;
+use wgpu_glyph::{GlyphCruncher, HorizontalAlign, Layout, Scale, Section, VerticalAlign};
 
-use super::{DrawPipe, Vec2};
+use crate::draw::{DrawPipe, Vec2};
+use kas::draw::Colour;
+use kas::geom::{Coord, Rect};
+use kas::theme::{TextClass, TextProperties};
+use kas::Align;
 
 /// Abstraction over text rendering
 ///
-/// TODO: this API is heavily dependent on `glyph_brush`. Eventually we want our
-/// own API, encapsulating translation functionality and with more default
-/// values (e.g. scale). When we get there, we should be able to move
-/// at least `FlatTheme` to `kas`.
+/// Note: the current API is designed to meet only current requirements since
+/// changes are expected to support external font shaping libraries.
 pub trait DrawText {
-    /// Queues a text section/layout.
-    fn draw_text<'a, S>(&mut self, section: S)
-    where
-        S: Into<Cow<'a, VariedSection<'a>>>;
+    /// Simple text drawing
+    ///
+    /// This allows text to be drawn according to a high-level API, and should
+    /// satisfy most uses.
+    fn text(&mut self, rect: Rect, text: &str, font_scale: f32, props: TextProperties, col: Colour);
 
-    /// Returns a bounding box for the section glyphs calculated using each glyph's
-    /// vertical & horizontal metrics.
+    /// Calculate size bound on text
     ///
-    /// If the section is empty or would result in no drawn glyphs will return `None`.
+    /// This may be used with [`DrawText::text`] to calculate size requirements
+    /// within [`kas::Layout::size_rules`].
     ///
-    /// Invisible glyphs, like spaces, are discarded during layout so trailing ones will
-    /// not affect the bounds.
-    ///
-    /// The bounds will always lay within the specified layout bounds, ie that returned
-    /// by the layout's `bounds_rect` function.
-    ///
-    /// Benefits from caching, see [caching behaviour](#caching-behaviour).
-    fn glyph_bounds<'a, S>(&mut self, section: S) -> Option<(Vec2, Vec2)>
-    where
-        S: Into<Cow<'a, VariedSection<'a>>>;
+    /// Bounds of `(f32::INFINITY, f32::INFINITY)` may be used if there are no
+    /// constraints. This parameter allows forcing line-wrapping behaviour
+    /// within the given bounds.
+    fn text_bound(
+        &mut self,
+        text: &str,
+        font_scale: f32,
+        bounds: (f32, f32),
+        line_wrap: bool,
+    ) -> (f32, f32);
 }
 
 impl DrawText for DrawPipe {
-    #[inline]
-    fn draw_text<'a, S>(&mut self, section: S)
-    where
-        S: Into<Cow<'a, VariedSection<'a>>>,
-    {
-        self.glyph_brush.queue(section)
+    fn text(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        font_scale: f32,
+        props: TextProperties,
+        col: Colour,
+    ) {
+        let bounds = Coord::from(rect.size);
+
+        // TODO: support justified alignment
+        let (h_align, h_offset) = match props.horiz {
+            Align::Begin | Align::Stretch => (HorizontalAlign::Left, 0),
+            Align::Centre => (HorizontalAlign::Center, bounds.0 / 2),
+            Align::End => (HorizontalAlign::Right, bounds.0),
+        };
+        let (v_align, v_offset) = match props.vert {
+            Align::Begin | Align::Stretch => (VerticalAlign::Top, 0),
+            Align::Centre => (VerticalAlign::Center, bounds.1 / 2),
+            Align::End => (VerticalAlign::Bottom, bounds.1),
+        };
+
+        let text_pos = rect.pos + Coord(h_offset, v_offset);
+
+        let layout = match props.class {
+            TextClass::Label | TextClass::EditMulti => Layout::default_wrap(),
+            TextClass::Button | TextClass::Edit => Layout::default_single_line(),
+        };
+        let layout = layout.h_align(h_align).v_align(v_align);
+
+        self.glyph_brush.queue(Section {
+            text,
+            screen_position: Vec2::from(text_pos).into(),
+            color: col.into(),
+            scale: Scale::uniform(font_scale),
+            bounds: Vec2::from(bounds).into(),
+            layout,
+            ..Section::default()
+        });
     }
 
     #[inline]
-    fn glyph_bounds<'a, S>(&mut self, section: S) -> Option<(Vec2, Vec2)>
-    where
-        S: Into<Cow<'a, VariedSection<'a>>>,
-    {
+    fn text_bound(
+        &mut self,
+        text: &str,
+        font_scale: f32,
+        bounds: (f32, f32),
+        line_wrap: bool,
+    ) -> (f32, f32) {
+        let layout = match line_wrap {
+            true => Layout::default_wrap(),
+            false => Layout::default_single_line(),
+        };
+
         self.glyph_brush
-            .glyph_bounds(section)
+            .glyph_bounds(Section {
+                text,
+                screen_position: (0.0, 0.0),
+                scale: Scale::uniform(font_scale),
+                bounds,
+                layout,
+                ..Section::default()
+            })
             .map(|rect| (Vec2(rect.min.x, rect.min.y), Vec2(rect.max.x, rect.max.y)))
+            .map(|(min, max)| max - min)
+            .unwrap_or(Vec2::splat(0.0))
+            .into()
     }
 }

--- a/kas-wgpu/src/draw/flat_round.rs
+++ b/kas-wgpu/src/draw/flat_round.rs
@@ -173,7 +173,14 @@ impl FlatRound {
     }
 
     /// Bounds on input: `aa < cc < dd < bb`.
-    pub fn rounded_frame(&mut self, pass: usize, outer: Rect, inner: Rect, col: Colour) {
+    pub fn rounded_frame(
+        &mut self,
+        pass: usize,
+        outer: Rect,
+        inner: Rect,
+        inner_radius: f32,
+        col: Colour,
+    ) {
         let aa = Vec2::from(outer.pos);
         let bb = aa + Vec2::from(outer.size);
         let mut cc = Vec2::from(inner.pos);
@@ -193,9 +200,9 @@ impl FlatRound {
             dd = cc;
         }
 
-        let col = col.into();
+        let inner = inner_radius.max(0.0).min(1.0);
 
-        let inner = 0.0;
+        let col = col.into();
 
         let ab = Vec2(aa.0, bb.1);
         let ba = Vec2(bb.0, aa.1);

--- a/kas-wgpu/src/draw/flat_round.rs
+++ b/kas-wgpu/src/draw/flat_round.rs
@@ -13,7 +13,7 @@ use kas::geom::{Rect, Size};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-struct Vertex(Vec2, Rgb, Vec2, Vec2);
+struct Vertex(Vec2, Rgb, f32, Vec2, Vec2);
 
 /// A pipeline for rendering rounded shapes
 pub struct FlatRound {
@@ -61,7 +61,7 @@ impl FlatRound {
         let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             layout: &pipeline_layout,
             vertex_stage: wgpu::ProgrammableStageDescriptor {
-                module: &shared.shaders.vert_322,
+                module: &shared.shaders.vert_3122,
                 entry_point: "main",
             },
             fragment_stage: Some(wgpu::ProgrammableStageDescriptor {
@@ -107,14 +107,20 @@ impl FlatRound {
                         shader_location: 1,
                     },
                     wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float2,
+                        format: wgpu::VertexFormat::Float,
                         offset: (size_of::<Vec2>() + size_of::<Rgb>()) as u64,
                         shader_location: 2,
                     },
                     wgpu::VertexAttributeDescriptor {
                         format: wgpu::VertexFormat::Float2,
-                        offset: (2 * size_of::<Vec2>() + size_of::<Rgb>()) as u64,
+                        offset: (size_of::<Vec2>() + size_of::<Rgb>() + size_of::<f32>()) as u64,
                         shader_location: 3,
+                    },
+                    wgpu::VertexAttributeDescriptor {
+                        format: wgpu::VertexFormat::Float2,
+                        offset: (2 * size_of::<Vec2>() + size_of::<Rgb>() + size_of::<f32>())
+                            as u64,
+                        shader_location: 4,
                     },
                 ],
             }],
@@ -189,6 +195,8 @@ impl FlatRound {
 
         let col = col.into();
 
+        let inner = 0.0;
+
         let ab = Vec2(aa.0, bb.1);
         let ba = Vec2(bb.0, aa.1);
         let cd = Vec2(cc.0, dd.1);
@@ -212,25 +220,25 @@ impl FlatRound {
 
         // We must add corners separately to ensure correct interpolation of dir
         // values, hence need 16 points:
-        let ab = Vertex(ab, col, nab, pab);
-        let ba = Vertex(ba, col, nba, pba);
-        let cd = Vertex(cd, col, n0, pab);
-        let dc = Vertex(dc, col, n0, pba);
+        let ab = Vertex(ab, col, inner, nab, pab);
+        let ba = Vertex(ba, col, inner, nba, pba);
+        let cd = Vertex(cd, col, inner, n0, pab);
+        let dc = Vertex(dc, col, inner, n0, pba);
 
-        let ac = Vertex(Vec2(aa.0, cc.1), col, na0, paa);
-        let ad = Vertex(Vec2(aa.0, dd.1), col, na0, pab);
-        let bc = Vertex(Vec2(bb.0, cc.1), col, nb0, pba);
-        let bd = Vertex(Vec2(bb.0, dd.1), col, nb0, pbb);
+        let ac = Vertex(Vec2(aa.0, cc.1), col, inner, na0, paa);
+        let ad = Vertex(Vec2(aa.0, dd.1), col, inner, na0, pab);
+        let bc = Vertex(Vec2(bb.0, cc.1), col, inner, nb0, pba);
+        let bd = Vertex(Vec2(bb.0, dd.1), col, inner, nb0, pbb);
 
-        let ca = Vertex(Vec2(cc.0, aa.1), col, n0a, paa);
-        let cb = Vertex(Vec2(cc.0, bb.1), col, n0b, pab);
-        let da = Vertex(Vec2(dd.0, aa.1), col, n0a, pba);
-        let db = Vertex(Vec2(dd.0, bb.1), col, n0b, pbb);
+        let ca = Vertex(Vec2(cc.0, aa.1), col, inner, n0a, paa);
+        let cb = Vertex(Vec2(cc.0, bb.1), col, inner, n0b, pab);
+        let da = Vertex(Vec2(dd.0, aa.1), col, inner, n0a, pba);
+        let db = Vertex(Vec2(dd.0, bb.1), col, inner, n0b, pbb);
 
-        let aa = Vertex(aa, col, naa, paa);
-        let bb = Vertex(bb, col, nbb, pbb);
-        let cc = Vertex(cc, col, n0, paa);
-        let dd = Vertex(dd, col, n0, pbb);
+        let aa = Vertex(aa, col, inner, naa, paa);
+        let bb = Vertex(bb, col, inner, nbb, pbb);
+        let cc = Vertex(cc, col, inner, n0, paa);
+        let dd = Vertex(dd, col, inner, n0, pbb);
 
         // TODO: the four sides are simple rectangles, hence could use simpler rendering
 

--- a/kas-wgpu/src/draw/mod.rs
+++ b/kas-wgpu/src/draw/mod.rs
@@ -26,8 +26,7 @@ pub(crate) use shaded_square::ShadedSquare;
 pub(crate) use shaders::ShaderManager;
 
 pub use draw_pipe::{DrawExt, ShadeStyle};
-pub use draw_text::DrawText;
-pub use kas::draw::{Colour, Draw};
+pub use kas::draw::{Colour, Draw, DrawText};
 pub use vector::{Quad, Vec2};
 
 /// 3-part colour data

--- a/kas-wgpu/src/draw/shaded_square.rs
+++ b/kas-wgpu/src/draw/shaded_square.rs
@@ -200,6 +200,40 @@ impl ShadedSquare {
         ]);
     }
 
+    /// Add a rect to the buffer, defined by two outer corners, `aa` and `bb`.
+    ///
+    /// Bounds on input: `aa < cc` and `-1 ≤ norm ≤ 1`.
+    pub fn shaded_rect(&mut self, pass: usize, rect: Rect, mut norm: Vec2, col: Colour) {
+        let aa = Vec2::from(rect.pos);
+        let bb = aa + Vec2::from(rect.size);
+
+        if !aa.lt(bb) {
+            // zero / negative size: nothing to draw
+            return;
+        }
+        if !Vec2::splat(-1.0).le(norm) || !norm.le(Vec2::splat(1.0)) {
+            norm = Vec2::splat(0.0);
+        }
+
+        let ab = Vec2(aa.0, bb.1);
+        let ba = Vec2(bb.0, aa.1);
+        let mid = (aa + bb) * 0.5;
+
+        let col = col.into();
+        let tt = (Vec2(0.0, -norm.1), Vec2(0.0, -norm.0));
+        let tl = (Vec2(-norm.1, 0.0), Vec2(-norm.0, 0.0));
+        let tb = (Vec2(0.0, norm.1), Vec2(0.0, norm.0));
+        let tr = (Vec2(norm.1, 0.0), Vec2(norm.0, 0.0));
+
+        #[rustfmt::skip]
+        self.add_vertices(pass, &[
+            Vertex(ba, col, tt.0), Vertex(mid, col, tt.1), Vertex(aa, col, tt.0),
+            Vertex(aa, col, tl.0), Vertex(mid, col, tl.1), Vertex(ab, col, tl.0),
+            Vertex(ab, col, tb.0), Vertex(mid, col, tb.1), Vertex(bb, col, tb.0),
+            Vertex(bb, col, tr.0), Vertex(mid, col, tr.1), Vertex(ba, col, tr.0),
+        ]);
+    }
+
     #[inline]
     pub fn frame(&mut self, pass: usize, outer: Rect, inner: Rect, col: Colour) {
         let norm = Vec2::splat(0.0);
@@ -246,10 +280,10 @@ impl ShadedSquare {
         let dc = Vec2(dd.0, cc.1);
 
         let col = col.into();
-        let tt = (Vec2(0.0, -norm.0), Vec2(0.0, -norm.1));
-        let tl = (Vec2(-norm.0, 0.0), Vec2(-norm.1, 0.0));
-        let tb = (Vec2(0.0, norm.0), Vec2(0.0, norm.1));
-        let tr = (Vec2(norm.0, 0.0), Vec2(norm.1, 0.0));
+        let tt = (Vec2(0.0, -norm.1), Vec2(0.0, -norm.0));
+        let tl = (Vec2(-norm.1, 0.0), Vec2(-norm.0, 0.0));
+        let tb = (Vec2(0.0, norm.1), Vec2(0.0, norm.0));
+        let tr = (Vec2(norm.1, 0.0), Vec2(norm.0, 0.0));
 
         #[rustfmt::skip]
         self.add_vertices(pass, &[

--- a/kas-wgpu/src/draw/shaders.rs
+++ b/kas-wgpu/src/draw/shaders.rs
@@ -15,6 +15,7 @@ use wgpu::ShaderModule;
 /// Not really optimal (we could embed SPIR-V directly or load shaders from
 /// external resources), but simple to set up and use.
 pub struct ShaderManager {
+    pub vert_3122: ShaderModule,
     pub vert_32: ShaderModule,
     pub vert_322: ShaderModule,
     pub vert_3222: ShaderModule,
@@ -26,6 +27,11 @@ pub struct ShaderManager {
 impl ShaderManager {
     pub fn new(device: &wgpu::Device) -> Result<Self, Error> {
         let mut compiler = Compiler::new().unwrap();
+
+        let fname = "shaders/scaled3122.vert";
+        let source = include_str!("shaders/scaled3122.vert");
+        let artifact = compiler.compile_into_spirv(source, Vertex, fname, "main", None)?;
+        let vert_3122 = device.create_shader_module(&artifact.as_binary());
 
         let fname = "shaders/scaled32.vert";
         let source = include_str!("shaders/scaled32.vert");
@@ -58,6 +64,7 @@ impl ShaderManager {
         let frag_shaded_round = device.create_shader_module(&artifact.as_binary());
 
         Ok(ShaderManager {
+            vert_3122,
             vert_32,
             vert_322,
             vert_3222,

--- a/kas-wgpu/src/draw/shaders/flat_round.frag
+++ b/kas-wgpu/src/draw/shaders/flat_round.frag
@@ -9,25 +9,26 @@
 precision mediump float;
 
 layout(location = 0) in vec3 fragColor;
-layout(location = 1) in vec2 dir;
-layout(location = 2) in vec2 off;
+layout(location = 1) in float inner;
+layout(location = 2) in vec2 pos;
+layout(location = 3) in vec2 off;
 
 layout(location = 0) out vec4 outColor;
 
-float sample_a(vec2 dir) {
-    vec2 dir2 = dir * dir;
-    float ss = dir2.x + dir2.y;
-    return (ss <= 1.0) ? 0.25 : 0.0;
+float sample_a(vec2 pos) {
+    vec2 pos2 = pos * pos;
+    float ss = pos2.x + pos2.y;
+    return (inner <= ss && ss <= 1.0) ? 0.25 : 0.0;
 }
 
 void main() {
     // Multi-sample alpha to avoid ugly aliasing.
     vec2 off1 = vec2(off.x, 3.0 * off.y);
     vec2 off2 = vec2(3.0 * off.x, off.y);
-    float alpha = sample_a(dir + off1)
-        + sample_a(dir - off1)
-        + sample_a(dir + off2)
-        + sample_a(dir - off2);
+    float alpha = sample_a(pos + off1)
+        + sample_a(pos - off1)
+        + sample_a(pos + off2)
+        + sample_a(pos - off2);
 
     outColor = vec4(fragColor, alpha);
 }

--- a/kas-wgpu/src/draw/shaders/scaled3122.vert
+++ b/kas-wgpu/src/draw/shaders/scaled3122.vert
@@ -1,0 +1,32 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(location = 0) in vec2 a_pos;
+layout(location = 1) in vec3 a_col;
+layout(location = 2) in float a1;
+layout(location = 3) in vec2 a2;
+layout(location = 4) in vec2 a3;
+
+layout(location = 0) out vec3 b_col;
+layout(location = 1) out float b1;
+layout(location = 2) out vec2 b2;
+layout(location = 3) out vec2 b3;
+
+layout(set = 0, binding = 0) uniform Locals {
+    vec2 scale;
+};
+
+const vec2 offset = { 1.0, 1.0 };
+
+void main() {
+    gl_Position = vec4(scale * a_pos - offset, 0.0, 1.0);
+    b_col = a_col;
+    b1 = a1;
+    b2 = a2;
+    b3 = a3;
+}

--- a/kas-wgpu/src/theme/flat_theme.rs
+++ b/kas-wgpu/src/theme/flat_theme.rs
@@ -226,10 +226,15 @@ impl<'a> theme::DrawHandle for DrawHandle<'a> {
 
         let inner = self.draw_edit_region(rect + self.offset, nav_col);
 
-        // TODO: draw an X, not a square!
         if let Some(col) = self.cols.check_mark_state(highlights, checked) {
-            let inner = inner.shrink(self.window.dims.margin);
-            self.draw.rect(self.pass, inner, col);
+            let radius = (inner.size.0 + inner.size.1) / 16;
+            let inner = inner.shrink(self.window.dims.margin + radius);
+            let p1 = inner.pos;
+            let p2 = inner.pos + inner.size;
+            let radius = radius as f32;
+            self.draw.rounded_line(self.pass, p1, p2, radius, col);
+            self.draw
+                .rounded_line(self.pass, Coord(p1.0, p2.1), Coord(p2.0, p1.1), radius, col);
         }
     }
 

--- a/kas-wgpu/src/theme/flat_theme.rs
+++ b/kas-wgpu/src/theme/flat_theme.rs
@@ -228,6 +228,7 @@ impl<'a> theme::DrawHandle for DrawHandle<'a> {
 
         // TODO: draw an X, not a square!
         if let Some(col) = self.cols.check_mark_state(highlights, checked) {
+            let inner = inner.shrink(self.window.dims.margin);
             self.draw.rect(self.pass, inner, col);
         }
     }
@@ -245,6 +246,7 @@ impl<'a> theme::DrawHandle for DrawHandle<'a> {
         let inner = self.draw_edit_region(rect + self.offset, nav_col);
 
         if let Some(col) = self.cols.check_mark_state(highlights, checked) {
+            let inner = inner.shrink(self.window.dims.margin);
             self.draw.circle(self.pass, inner, 0.3, col);
         }
     }

--- a/kas-wgpu/src/theme/flat_theme.rs
+++ b/kas-wgpu/src/theme/flat_theme.rs
@@ -8,17 +8,16 @@
 //! Widget size and appearance can be modified through themes.
 
 use std::f32;
-use wgpu_glyph::{Font, HorizontalAlign, Layout, Scale, Section, VerticalAlign};
+use wgpu_glyph::Font;
 
 use kas::draw::{Colour, Draw};
 use kas::event::HighlightState;
 use kas::geom::{Coord, Rect};
 use kas::theme::{self, TextClass, TextProperties, ThemeAction, ThemeApi};
-use kas::Align;
 use kas::Direction;
 
 use super::{Dimensions, DimensionsParams, DimensionsWindow};
-use crate::draw::{DrawExt, DrawPipe, DrawText, Vec2};
+use crate::draw::{DrawExt, DrawPipe, DrawText};
 use crate::resources::colours::ThemeColours;
 
 /// A simple flat theme.
@@ -167,43 +166,13 @@ impl<'a> theme::DrawHandle for DrawHandle<'a> {
     }
 
     fn text(&mut self, rect: Rect, text: &str, props: TextProperties) {
-        let bounds = Coord::from(rect.size);
-
+        let scale = self.window.dims.font_scale;
         let col = match props.class {
             TextClass::Label => self.cols.label_text,
             TextClass::Button => self.cols.button_text,
             TextClass::Edit | TextClass::EditMulti => self.cols.text,
         };
-
-        // TODO: support justified alignment
-        let (h_align, h_offset) = match props.horiz {
-            Align::Begin | Align::Stretch => (HorizontalAlign::Left, 0),
-            Align::Centre => (HorizontalAlign::Center, bounds.0 / 2),
-            Align::End => (HorizontalAlign::Right, bounds.0),
-        };
-        let (v_align, v_offset) = match props.vert {
-            Align::Begin | Align::Stretch => (VerticalAlign::Top, 0),
-            Align::Centre => (VerticalAlign::Center, bounds.1 / 2),
-            Align::End => (VerticalAlign::Bottom, bounds.1),
-        };
-
-        let text_pos = rect.pos + self.offset + Coord(h_offset, v_offset);
-
-        let layout = match props.class {
-            TextClass::Label | TextClass::EditMulti => Layout::default_wrap(),
-            TextClass::Button | TextClass::Edit => Layout::default_single_line(),
-        };
-        let layout = layout.h_align(h_align).v_align(v_align);
-
-        self.draw.draw_text(Section {
-            text,
-            screen_position: Vec2::from(text_pos).into(),
-            color: col.into(),
-            scale: Scale::uniform(self.window.dims.font_scale),
-            bounds: Vec2::from(bounds).into(),
-            layout,
-            ..Section::default()
-        });
+        self.draw.text(rect + self.offset, text, scale, props, col);
     }
 
     fn button(&mut self, rect: Rect, highlights: HighlightState) {

--- a/kas-wgpu/src/theme/flat_theme.rs
+++ b/kas-wgpu/src/theme/flat_theme.rs
@@ -198,20 +198,17 @@ impl<'a> theme::DrawHandle for DrawHandle<'a> {
     }
 
     fn button(&mut self, rect: Rect, highlights: HighlightState) {
-        let mut outer = rect + self.offset;
+        let outer = rect + self.offset;
         let col = self.cols.button_state(highlights);
 
         let inner = outer.shrink(self.window.dims.button_frame);
         self.draw.rounded_frame(self.pass, outer, inner, 0.0, col);
+        self.draw.rect(self.pass, inner, col);
 
         if let Some(col) = self.cols.nav_region(highlights) {
-            let diff = self.window.dims.button_frame - self.window.dims.margin;
-            outer = outer.shrink(diff);
-            // Note: we rely on this drawing *after* rounded_frame
-            self.draw.frame(self.pass, outer, inner, col);
+            let outer = outer.shrink(self.window.dims.button_frame / 3);
+            self.draw.rounded_frame(self.pass, outer, inner, 0.5, col);
         }
-
-        self.draw.rect(self.pass, inner, col);
     }
 
     fn edit_box(&mut self, rect: Rect, highlights: HighlightState) {

--- a/kas-wgpu/src/theme/flat_theme.rs
+++ b/kas-wgpu/src/theme/flat_theme.rs
@@ -226,6 +226,7 @@ impl<'a> theme::DrawHandle for DrawHandle<'a> {
 
         let inner = self.draw_edit_region(rect + self.offset, nav_col);
 
+        // TODO: draw an X, not a square!
         if let Some(col) = self.cols.check_mark_state(highlights, checked) {
             self.draw.rect(self.pass, inner, col);
         }
@@ -233,8 +234,19 @@ impl<'a> theme::DrawHandle for DrawHandle<'a> {
 
     #[inline]
     fn radiobox(&mut self, rect: Rect, checked: bool, highlights: HighlightState) {
-        // TODO: distinct
-        self.checkbox(rect, checked, highlights);
+        let nav_col = self.cols.nav_region(highlights).or_else(|| {
+            if checked {
+                Some(self.cols.text_area)
+            } else {
+                None
+            }
+        });
+
+        let inner = self.draw_edit_region(rect + self.offset, nav_col);
+
+        if let Some(col) = self.cols.check_mark_state(highlights, checked) {
+            self.draw.circle(self.pass, inner, 0.3, col);
+        }
     }
 
     fn scrollbar(

--- a/kas-wgpu/src/theme/mod.rs
+++ b/kas-wgpu/src/theme/mod.rs
@@ -5,11 +5,9 @@
 
 //! Themes
 
-mod dimensions;
 mod flat_theme;
 mod shaded_theme;
 
-pub(crate) use dimensions::{Dimensions, DimensionsParams, DimensionsWindow};
-
 pub use flat_theme::FlatTheme;
+pub use kas::theme::*;
 pub use shaded_theme::ShadedTheme;

--- a/kas-wgpu/src/theme/shaded_theme.rs
+++ b/kas-wgpu/src/theme/shaded_theme.rs
@@ -138,7 +138,7 @@ impl<'a> DrawHandle<'a> {
     /// Return the inner rect.
     fn draw_edit_region(&mut self, mut outer: Rect, nav_col: Option<Colour>) -> Rect {
         let mut inner = outer.shrink(self.window.dims.frame);
-        let style = ShadeStyle::Square(Vec2(0.0, -0.8));
+        let style = ShadeStyle::Square(Vec2(-0.8, 0.0));
         self.draw
             .shaded_frame(self.pass, outer, inner, style, self.cols.background);
 
@@ -226,9 +226,9 @@ impl<'a> theme::DrawHandle for DrawHandle<'a> {
 
         let inner = self.draw_edit_region(rect + self.offset, nav_col);
 
-        // TODO: draw an X, not a square!
         if let Some(col) = self.cols.check_mark_state(highlights, checked) {
-            self.draw.rect(self.pass, inner, col);
+            let style = ShadeStyle::Square(Vec2(0.0, 0.4));
+            self.draw.shaded_box(self.pass, inner, style, col);
         }
     }
 
@@ -245,7 +245,8 @@ impl<'a> theme::DrawHandle for DrawHandle<'a> {
         let inner = self.draw_edit_region(rect + self.offset, nav_col);
 
         if let Some(col) = self.cols.check_mark_state(highlights, checked) {
-            self.draw.circle(self.pass, inner, 0.3, col);
+            let style = ShadeStyle::Round(Vec2(0.0, 1.0));
+            self.draw.shaded_box(self.pass, inner, style, col);
         }
     }
 

--- a/kas-wgpu/src/theme/shaded_theme.rs
+++ b/kas-wgpu/src/theme/shaded_theme.rs
@@ -177,20 +177,18 @@ impl<'a> theme::DrawHandle for DrawHandle<'a> {
     }
 
     fn button(&mut self, rect: Rect, highlights: HighlightState) {
-        let mut outer = rect + self.offset;
+        let outer = rect + self.offset;
+        let inner = outer.shrink(self.window.dims.button_frame);
         let col = self.cols.button_state(highlights);
 
-        let mut inner = outer.shrink(self.window.dims.button_frame);
         let style = ShadeStyle::Round(Vec2(0.0, 0.6));
         self.draw.shaded_frame(self.pass, outer, inner, style, col);
+        self.draw.rect(self.pass, inner, col);
 
         if let Some(col) = self.cols.nav_region(highlights) {
-            outer = inner;
-            inner = outer.shrink(self.window.dims.margin);
-            self.draw.frame(self.pass, outer, inner, col);
+            let outer = outer.shrink(self.window.dims.button_frame / 3);
+            self.draw.rounded_frame(self.pass, outer, inner, 0.5, col);
         }
-
-        self.draw.rect(self.pass, inner, col);
     }
 
     fn edit_box(&mut self, rect: Rect, highlights: HighlightState) {

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -15,6 +15,7 @@ mod colour;
 use std::any::Any;
 
 use crate::geom::Rect;
+use crate::theme::TextProperties;
 
 pub use colour::Colour;
 
@@ -52,4 +53,32 @@ pub trait Draw {
     /// It is expected that the `outer` rect contains the `inner` rect.
     /// Failure may result in graphical glitches.
     fn frame(&mut self, region: Self::Region, outer: Rect, inner: Rect, col: Colour);
+}
+
+/// Abstraction over text rendering
+///
+/// Note: the current API is designed to meet only current requirements since
+/// changes are expected to support external font shaping libraries.
+pub trait DrawText {
+    /// Simple text drawing
+    ///
+    /// This allows text to be drawn according to a high-level API, and should
+    /// satisfy most uses.
+    fn text(&mut self, rect: Rect, text: &str, font_scale: f32, props: TextProperties, col: Colour);
+
+    /// Calculate size bound on text
+    ///
+    /// This may be used with [`DrawText::text`] to calculate size requirements
+    /// within [`kas::Layout::size_rules`].
+    ///
+    /// Bounds of `(f32::INFINITY, f32::INFINITY)` may be used if there are no
+    /// constraints. This parameter allows forcing line-wrapping behaviour
+    /// within the given bounds.
+    fn text_bound(
+        &mut self,
+        text: &str,
+        font_scale: f32,
+        bounds: (f32, f32),
+        line_wrap: bool,
+    ) -> (f32, f32);
 }

--- a/src/theme/dimensions.rs
+++ b/src/theme/dimensions.rs
@@ -10,12 +10,11 @@
 use std::any::Any;
 use std::f32;
 
-use kas::geom::Size;
-use kas::layout::{AxisInfo, SizeRules, StretchPolicy};
-use kas::theme::{self, TextClass};
-use kas::Direction::{Horizontal, Vertical};
-
-use crate::draw::{DrawPipe, DrawText};
+use crate::draw::DrawText;
+use crate::geom::Size;
+use crate::layout::{AxisInfo, SizeRules, StretchPolicy};
+use crate::theme::{self, TextClass};
+use crate::Direction::{Horizontal, Vertical};
 
 /// Parameterisation of [`Dimensions`]
 ///
@@ -33,6 +32,7 @@ pub struct DimensionsParams {
     pub scrollbar_size: f32,
 }
 
+/// Dimensions available within [`DimensionsWindow`]
 #[derive(Clone, Debug)]
 pub struct Dimensions {
     pub font_scale: f32,
@@ -66,6 +66,7 @@ impl Dimensions {
     }
 }
 
+/// A convenient implementation of [`kas::theme::Window`]
 pub struct DimensionsWindow {
     pub dims: Dimensions,
 }
@@ -78,20 +79,20 @@ impl DimensionsWindow {
     }
 }
 
-impl theme::Window<DrawPipe> for DimensionsWindow {
+impl<Draw: DrawText + 'static> theme::Window<Draw> for DimensionsWindow {
     #[cfg(not(feature = "gat"))]
-    type SizeHandle = SizeHandle<'static>;
+    type SizeHandle = SizeHandle<'static, Draw>;
     #[cfg(feature = "gat")]
-    type SizeHandle<'a> = SizeHandle<'a>;
+    type SizeHandle<'a> = SizeHandle<'a, Draw>;
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn size_handle<'a>(&'a mut self, draw: &'a mut DrawPipe) -> Self::SizeHandle {
+    unsafe fn size_handle<'a>(&'a mut self, draw: &'a mut Draw) -> Self::SizeHandle {
         // We extend lifetimes (unsafe) due to the lack of associated type generics.
-        let handle = SizeHandle::new(draw, &self.dims);
-        std::mem::transmute::<SizeHandle<'a>, SizeHandle<'static>>(handle)
+        let h: SizeHandle<'a, Draw> = SizeHandle::new(draw, &self.dims);
+        std::mem::transmute(h)
     }
     #[cfg(feature = "gat")]
-    fn size_handle<'a>(&'a mut self, draw: &'a mut DrawPipe) -> Self::SizeHandle<'a> {
+    fn size_handle<'a>(&'a mut self, draw: &'a mut Draw) -> Self::SizeHandle<'a> {
         SizeHandle::new(draw, &self.dims)
     }
 
@@ -100,18 +101,18 @@ impl theme::Window<DrawPipe> for DimensionsWindow {
     }
 }
 
-pub struct SizeHandle<'a> {
-    draw: &'a mut DrawPipe,
+pub struct SizeHandle<'a, Draw> {
+    draw: &'a mut Draw,
     dims: &'a Dimensions,
 }
 
-impl<'a> SizeHandle<'a> {
-    pub fn new(draw: &'a mut DrawPipe, dims: &'a Dimensions) -> Self {
+impl<'a, Draw> SizeHandle<'a, Draw> {
+    pub fn new(draw: &'a mut Draw, dims: &'a Dimensions) -> Self {
         SizeHandle { draw, dims }
     }
 }
 
-impl<'a> theme::SizeHandle for SizeHandle<'a> {
+impl<'a, Draw: DrawText> theme::SizeHandle for SizeHandle<'a, Draw> {
     fn outer_frame(&self) -> (Size, Size) {
         let f = self.dims.frame as u32;
         (Size::uniform(f), Size::uniform(f))

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -20,6 +20,7 @@
 
 use kas::Align;
 
+mod dimensions;
 #[cfg(all(feature = "stack_dst", not(feature = "gat")))]
 mod multi_theme;
 #[cfg(all(feature = "stack_dst", not(feature = "gat")))]
@@ -27,6 +28,7 @@ mod theme_dst;
 mod theme_handle;
 mod theme_traits;
 
+pub use dimensions::{Dimensions, DimensionsParams, DimensionsWindow};
 #[cfg(all(feature = "stack_dst", not(feature = "gat")))]
 pub use multi_theme::MultiTheme;
 #[cfg(all(feature = "stack_dst", not(feature = "gat")))]


### PR DESCRIPTION
First, this switches to a higher-level (and more limiting) API in `DrawText`. This is not sufficient for all usages (though nor was the previous); fleshing this out properly can wait until the text-processing work lands (which will be a major step by itself).

Second, this adds several new drawing routines, especially using the `lfat_round` shader, and uses these to significantly improve rendering (navigation-highlights and check-/radio-box marks in both themes, and a few more things in the flat theme).

Third, this moves some of the draw API up to `kas` (core crate). Much of the theme stuff does not need to be in `kas_wgpu`. But much of it also doesn't need to be in `kas`, so perhaps it's time for a `kas-theme` crate (next PR).